### PR TITLE
[tls] Fix security gaps in toy TLS implementation

### DIFF
--- a/coding/crypto/aes.py
+++ b/coding/crypto/aes.py
@@ -555,7 +555,12 @@ def _decrypt_moo(readable, writable, moo):
             # PKCS#7 padding
             # (see https://en.wikipedia.org/wiki/Padding_(cryptography)#PKCS7)
             if ((moo == MoO.ECB) or (moo == MoO.CBC)) and last_block:
-                bs = bs[:-bs[-1]]
+                pad_len = bs[-1]
+                if pad_len < 1 or pad_len > NB * NB:
+                    raise ValueError("invalid PKCS#7 padding")
+                if bs[-pad_len:] != bytes([pad_len] * pad_len):
+                    raise ValueError("invalid PKCS#7 padding")
+                bs = bs[:-pad_len]
             else:
                 bs = bytes(bs)
 

--- a/coding/crypto/rsa.py
+++ b/coding/crypto/rsa.py
@@ -40,6 +40,10 @@ AES_KEY_SIZE = 256
 SHA2_DIGEST = "SHA512_256"
 BUF_SIZE = 4096
 
+# see https://crypto.stackexchange.com/a/3113,
+# and https://www.rfc-editor.org/rfc/rfc6376#section-3.3.1
+RSA_STANDARD_PUBLIC_EXPONENT = 65537
+
 
 class BadKeyError(Exception):
     """
@@ -106,7 +110,7 @@ def genkeys(p, q):
 
     n = p * q  # modulus
 
-    e = 65537  # public exponent (see https://crypto.stackexchange.com/a/3113)
+    e = RSA_STANDARD_PUBLIC_EXPONENT
     # calculate the exponent using Euler's totient (Φ) instead of the
     # Carmichael (λ) one (easier implementation)
     # see https://en.wikipedia.org/wiki/RSA_(cryptosystem)#Key_generation


### PR DESCRIPTION
- Validate PKCS#7 padding bytes on decrypt in aes.py
- Fix transcript canonicalization: snapshot length before recv instead of re-serializing JSON to compute byte offsets
- Store public exponent in private key file (n, e, d) instead of hardcoding e=65537 in server CLI