### PR TITLE
[coding/ai] Add trace-process.sh wrapper and config file examples

### DIFF
--- a/coding/ai-ca-tools/README.md
+++ b/coding/ai-ca-tools/README.md
@@ -1,6 +1,6 @@
 # AI Coding Agents supervision & monitoring tools
 
-[bpftrace](https://github.com/bpftrace/bpftrace) scripts to monitor what AI coding agents are doing on your system. They trace a target process and all its descendants using kernel tracepoints, kprobes, and uprobes.
+[bpftrace](https://github.com/bpftrace/bpftrace) scripts to monitor what a process and all its descendants are doing on your system, using kernel tracepoints, kprobes, and uprobes.
 
 Requires: Linux with BTF support (`CONFIG_DEBUG_INFO_BTF=y`), bpftrace >= 0.21.
 
@@ -24,7 +24,7 @@ sudo bpftrace trace-netcalls.bt <PID>
 
 ### trace-files.bt
 
-Monitors file operations: opens (read/write/create), reads, writes, deletes, renames, chmod, and chown. Tracks fd-to-filename mappings so that read/write syscalls display the file path and byte count.
+Monitors file operations: opens (read/write/create), reads, writes, directory creation, deletes, renames, chmod, and chown. Tracks fd-to-filename mappings so that read/write syscalls display the file path and byte count.
 
 ```
 sudo bpftrace trace-files.bt <PID>
@@ -32,23 +32,61 @@ sudo bpftrace trace-files.bt <PID>
 
 ### trace-suspicious.bt
 
-Monitors suspicious or potentially abusive operations that a legitimate coding agent should rarely or never perform:
+Monitors suspicious or potentially dangerous operations:
 
-- **Credential/secret access** — opening SSH keys, GPG keyrings, `.aws/`, `.env`, token/secret files, `/etc/shadow`
+- **Credential/secret access** — opening SSH keys, GPG keyrings, `.aws/`, `.env`, token/secret files, `.netrc`
 - **Privilege escalation** — `setuid`/`setgid`/`setresuid`/`setresgid`, `capset`
 - **Persistence mechanisms** — writing to crontabs, systemd unit files, shell startup files (`.bashrc`, `.zshrc`, etc.)
 - **System manipulation** — `ptrace` (process injection), `mount`/`umount`, kernel module loading, hostname changes
 - **Covert execution** — `memfd_create` (fileless execution), raw socket creation
+- **Listening sockets / reverse shells** — `bind`, `listen`, `accept`/`accept4`
+- **Cross-process memory access** — `process_vm_readv`/`process_vm_writev`
+- **Namespace / sandbox escape** — `unshare`, `chroot`, `pivot_root`
+- **Code injection / anti-forensics** — `mprotect` with PROT_EXEC, `prctl` PR_SET_DUMPABLE=0, `seccomp`, `personality`, `userfaultfd`
+- **Symlink / hardlink attacks** — `symlinkat`, `linkat`
+- **Credential keyring access** — `keyctl`
+- **Destructive actions** — `reboot`, `kill` outside watched process tree
 - **Permission manipulation** — `chmod` with setuid/setgid bits
 
 ```
 sudo bpftrace trace-suspicious.bt <PID>
 ```
 
-### spy-agent.sh
+### trace-process.sh
 
-Runs all four scripts in parallel against the same target PID. Ctrl-C stops all.
+Wrapper that launches or attaches to a process and runs the bpftrace scripts in parallel. Traces are written to a log file (not the terminal). Supports selective tracer disabling and file-tracer output filtering.
 
 ```
-sudo ./spy-agent.sh <PID>
+# Run mode — launch a command and trace it
+./trace-process.sh -- <COMMAND> [ARGS...]
+
+# Attach mode — trace an already-running process
+./trace-process.sh -p <PID>
+
+# With a config file (e.g. for Claude Code)
+./trace-process.sh -c confs/claude.conf -- claude --resume
+
+# Disable specific tracers
+./trace-process.sh -EN -- my-program run
+
+# Follow traces in real time from another terminal
+tail -f <log-file>
 ```
+
+See `./trace-process.sh -h` for all options.
+
+### Configuration
+
+`trace-process.sh` options can be set via CLI flags, environment variables, or a config file sourced with `-c`. Process-specific config files are provided in the `confs/` directory for popular AI coding agents:
+
+| Config file | Tool |
+|---|---|
+| `confs/claude.conf` | [Claude Code](https://github.com/anthropics/claude-code) |
+| `confs/codex.conf` | [OpenAI Codex CLI](https://github.com/openai/codex) |
+| `confs/aider.conf` | [Aider](https://github.com/paul-gauthier/aider) |
+| `confs/cline.conf` | [Cline](https://github.com/cline/cline) |
+| `confs/goose.conf` | [Goose](https://github.com/block/goose) |
+| `confs/continue.conf` | [Continue](https://github.com/continuedev/continue) |
+| `confs/openhands.conf` | [OpenHands](https://github.com/All-Hands-AI/OpenHands) |
+
+Precedence: defaults < env vars < config file < CLI options.

--- a/coding/ai-ca-tools/confs/aider.conf
+++ b/coding/ai-ca-tools/confs/aider.conf
@@ -1,0 +1,6 @@
+# trace-process.sh configuration for Aider
+#
+# Usage: ./trace-process.sh -c aider.conf -- aider
+
+# Filter out noisy file-tracer entries from Aider's internal files
+FILE_FILTER="[[:space:]](/dev/tty$|${HOME}/\.aider\.conf\.yml|\.aider\.tags\.cache\.v3/|\.aider\.input\.history|\.aider\.chat\.history\.md)"

--- a/coding/ai-ca-tools/confs/claude.conf
+++ b/coding/ai-ca-tools/confs/claude.conf
@@ -1,0 +1,6 @@
+# trace-process.sh configuration for Claude Code
+#
+# Usage: ./trace-process.sh -c claude.conf -- claude --resume
+
+# Filter out noisy file-tracer entries from Claude's internal files
+FILE_FILTER="[[:space:]](/dev/tty$|${HOME}/\.claude/|${HOME}/\.claude\.json)"

--- a/coding/ai-ca-tools/confs/cline.conf
+++ b/coding/ai-ca-tools/confs/cline.conf
@@ -1,0 +1,6 @@
+# trace-process.sh configuration for Cline
+#
+# Usage: ./trace-process.sh -c cline.conf -- cline
+
+# Filter out noisy file-tracer entries from Cline's internal files
+FILE_FILTER="[[:space:]](/dev/tty$|${HOME}/\.cline/)"

--- a/coding/ai-ca-tools/confs/codex.conf
+++ b/coding/ai-ca-tools/confs/codex.conf
@@ -1,0 +1,6 @@
+# trace-process.sh configuration for OpenAI Codex CLI
+#
+# Usage: ./trace-process.sh -c codex.conf -- codex
+
+# Filter out noisy file-tracer entries from Codex's internal files
+FILE_FILTER="[[:space:]](/dev/tty$|${HOME}/\.codex/|\.codex/)"

--- a/coding/ai-ca-tools/confs/continue.conf
+++ b/coding/ai-ca-tools/confs/continue.conf
@@ -1,0 +1,6 @@
+# trace-process.sh configuration for Continue
+#
+# Usage: ./trace-process.sh -c continue.conf -- continue
+
+# Filter out noisy file-tracer entries from Continue's internal files
+FILE_FILTER="[[:space:]](/dev/tty$|${HOME}/\.continue/|\.continue/)"

--- a/coding/ai-ca-tools/confs/goose.conf
+++ b/coding/ai-ca-tools/confs/goose.conf
@@ -1,0 +1,6 @@
+# trace-process.sh configuration for Goose (Block)
+#
+# Usage: ./trace-process.sh -c goose.conf -- goose
+
+# Filter out noisy file-tracer entries from Goose's internal files
+FILE_FILTER="[[:space:]](/dev/tty$|${HOME}/\.config/goose/)"

--- a/coding/ai-ca-tools/confs/openhands.conf
+++ b/coding/ai-ca-tools/confs/openhands.conf
@@ -1,0 +1,6 @@
+# trace-process.sh configuration for OpenHands
+#
+# Usage: ./trace-process.sh -c openhands.conf -- openhands
+
+# Filter out noisy file-tracer entries from OpenHands' internal files
+FILE_FILTER="[[:space:]](/dev/tty$|${HOME}/\.openhands/)"

--- a/coding/ai-ca-tools/trace-all.sh
+++ b/coding/ai-ca-tools/trace-all.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# spy-agent.sh
+# trace-all.sh
 #
 # Runs the four individual bpftrace scripts (execs, files, netcalls,
 # suspicious) in parallel against the same target PID. Ctrl-C stops all.
@@ -23,7 +23,7 @@ cleanup() {
     kill 0 2>/dev/null
     wait 2>/dev/null
 }
-trap cleanup EXIT
+trap cleanup EXIT INT TERM QUIT HUP
 
 bpftrace "$SCRIPT_DIR/trace-execs.bt" "$PID" &
 bpftrace "$SCRIPT_DIR/trace-files.bt" "$PID" &

--- a/coding/ai-ca-tools/trace-files.bt
+++ b/coding/ai-ca-tools/trace-files.bt
@@ -6,13 +6,13 @@
  * specific process and its descendants.
  *
  * Requires: kernel BTF support (CONFIG_DEBUG_INFO_BTF=y), bpftrace >= 0.21
- * Usage: sudo bpftrace trace-ai-coding-agent-files.bt <PID>
+ * Usage: sudo bpftrace trace-files.bt <PID>
  */
 
 BEGIN
 {
     if ($1 == 0) {
-        printf("Usage: sudo bpftrace trace-ai-coding-agent-files.bt <PID>\n");
+        printf("Usage: sudo bpftrace trace-files.bt <PID>\n");
         exit();
     }
     printf("Monitoring file operations of PID %d (and their children)...\n", $1);

--- a/coding/ai-ca-tools/trace-netcalls.bt
+++ b/coding/ai-ca-tools/trace-netcalls.bt
@@ -13,8 +13,10 @@
  * (bpf_probe_read vs bpf_probe_read_user).
  *
  * Requires: kernel BTF support (CONFIG_DEBUG_INFO_BTF=y), bpftrace >= 0.21
- * Usage: sudo bpftrace trace-ai-coding-agent-netcalls.bt <PID>
+ * Usage: sudo bpftrace trace-netcalls.bt <PID>
  */
+
+config { unstable_macro=enable }
 
 // --- Macros ---
 
@@ -125,7 +127,7 @@ macro log_udp6($sk, $msg, size) {
 BEGIN
 {
     if ($1 == 0) {
-        printf("Usage: sudo bpftrace trace-ai-coding-agent-netcalls.bt <PID>\n");
+        printf("Usage: sudo bpftrace trace-netcalls.bt <PID>\n");
         exit();
     }
     printf("Monitoring network calls of PID %d (and their children)...\n", $1);

--- a/coding/ai-ca-tools/trace-process.sh
+++ b/coding/ai-ca-tools/trace-process.sh
@@ -1,0 +1,307 @@
+#!/usr/bin/env bash
+#
+# trace-process.sh
+#
+# Attaches bpftrace scripts (execs, files, netcalls, suspicious) with
+# elevated privileges to monitor a process and all its descendants.
+#
+# Two modes:
+#   Run mode:    Launch a command and trace it (default)
+#   Attach mode: Attach to an already-running process (-p PID)
+#
+# In run mode, trace output is written to a log file (not the terminal)
+# to avoid interleaving with the process's own output. Use -o/--output
+# to set a custom path, otherwise a temporary file is used.
+# In attach mode (-p), traces go to stdout by default.
+#
+# Options can also be set via environment variables or a config file
+# sourced with -c/--config (see --help for details).
+#
+# Stops tracing when the process exits or on Ctrl-C / SIGTERM.
+#
+# Usage:
+#   ./trace-process.sh [OPTIONS] -- <COMMAND> [ARGS...]
+#   ./trace-process.sh [OPTIONS] -p <PID>
+#
+# Options:
+#   -c, --config FILE          Source env vars from FILE before applying
+#                              defaults (CLI options override config)
+#   -p, --pid PID              Attach to an existing process instead of
+#                              launching a new one
+#   -o, --output FILE          Write traces to FILE (default: temp file)
+#   -f, --filter REGEX         Exclude file-tracer lines matching REGEX
+#                              (grep -vE; see claude.conf for an example)
+#       --no-filter            Disable the exclusion filter
+#   -E, --disable-execs        Disable subprocess/exec tracing
+#   -F, --disable-files        Disable file operation tracing
+#   -N, --disable-netcalls     Disable network call tracing
+#   -S, --disable-suspicious   Disable suspicious operation tracing
+#   -h, --help                 Show this help message
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# --- Defaults (env vars and config file values take precedence) ---
+TRACE_EXECS="${TRACE_EXECS:-1}"
+TRACE_FILES="${TRACE_FILES:-1}"
+TRACE_NETCALLS="${TRACE_NETCALLS:-1}"
+TRACE_SUSPICIOUS="${TRACE_SUSPICIOUS:-1}"
+LOG_FILE="${LOG_FILE:-}"
+ATTACH_PID="${ATTACH_PID:-}"
+FILE_FILTER="${FILE_FILTER:-}"
+
+# --- Usage ---
+usage() {
+    cat >&2 <<EOF
+Usage:
+  $0 [OPTIONS] -- <COMMAND> [ARGS...]   (run mode)
+  $0 [OPTIONS] -p <PID>                 (attach mode)
+
+Attach bpftrace monitors to a process.
+
+In run mode, the command is launched as the current user and traced.
+In attach mode (-p), tracers attach to an already-running process.
+
+This script must NOT be run as root — the traced process should run
+unprivileged. Sudo credentials will be requested for bpftrace only.
+
+In run mode, trace output goes to a log file (to avoid interleaving with
+the process's own output). To follow traces in real time, open another
+terminal and run:
+
+  tail -f <log-file>
+
+In attach mode (-p), traces go to stdout by default. Use -o/--output to
+redirect to a file instead.
+
+Options:
+  -c, --config FILE          Source env vars from FILE (see below)
+  -p, --pid PID              Attach to an existing process instead of
+                             launching a new one
+  -o, --output FILE          Write traces to FILE (default: temp file)
+  -f, --filter REGEX         Exclude file-tracer lines matching REGEX
+                             (grep -vE; see claude.conf for an example)
+      --no-filter            Disable the exclusion filter
+  -E, --disable-execs        Disable subprocess/exec tracing
+  -F, --disable-files        Disable file operation tracing
+  -N, --disable-netcalls     Disable network call tracing
+  -S, --disable-suspicious   Disable suspicious operation tracing
+  -h, --help                 Show this help message
+
+Configuration:
+  Use -c/--config or set env vars directly. The config file is sourced
+  as bash and can set any of these variables:
+
+    TRACE_EXECS=0
+    TRACE_NETCALLS=0
+    FILE_FILTER="/dev/tty|/proc/"
+    LOG_FILE="/tmp/my-traces.log"
+
+  Precedence: defaults < env vars < config file < CLI options.
+  Process-specific configs can be provided (e.g. claude.conf).
+
+Example:
+  $0 -c claude.conf -- claude --resume
+  $0 -p 12345
+  $0 -c my.conf -o traces.log -- my-program run
+  $0 -EN -- my-program run
+  $0 --no-filter -- aider
+  TRACE_EXECS=0 $0 -- codex
+EOF
+    exit 1
+}
+
+# --- Refuse to run as root ---
+if [[ $(id -u) -eq 0 ]]; then
+    echo "Error: do not run this script as root or via sudo." >&2
+    echo "The traced process must run as an unprivileged user." >&2
+    echo "Sudo will be used internally for bpftrace only." >&2
+    exit 1
+fi
+
+# --- Parse options with getopt ---
+OPTS=$(getopt -o 'c:p:o:f:EFNSh' -l 'config:,pid:,output:,filter:,no-filter,disable-execs,disable-files,disable-netcalls,disable-suspicious,help' -n "$0" -- "$@") || usage
+eval set -- "$OPTS"
+
+while true; do
+    case "$1" in
+        -c|--config)             source "$2";          shift 2 ;;
+        -p|--pid)                ATTACH_PID="$2";     shift 2 ;;
+        -o|--output)             LOG_FILE="$2";       shift 2 ;;
+        -f|--filter)             FILE_FILTER="$2";    shift 2 ;;
+        --no-filter)             FILE_FILTER="";      shift ;;
+        -E|--disable-execs)      TRACE_EXECS=0;       shift ;;
+        -F|--disable-files)      TRACE_FILES=0;       shift ;;
+        -N|--disable-netcalls)   TRACE_NETCALLS=0;    shift ;;
+        -S|--disable-suspicious) TRACE_SUSPICIOUS=0;  shift ;;
+        -h|--help)               usage ;;
+        --)                      shift; break ;;
+    esac
+done
+
+# --- Validate mode ---
+if [[ -n "$ATTACH_PID" && $# -gt 0 ]]; then
+    echo "Error: -p/--pid and a command are mutually exclusive" >&2
+    usage
+fi
+
+if [[ -z "$ATTACH_PID" && $# -eq 0 ]]; then
+    echo "Error: specify a command or use -p/--pid to attach" >&2
+    usage
+fi
+
+# --- Output setup ---
+# In attach mode, default to stdout (no interleaving risk since we
+# didn't launch the process). In run mode, default to a temp file.
+LOG_TO_STDOUT=0
+if [[ -z "$LOG_FILE" ]]; then
+    if [[ -n "$ATTACH_PID" ]]; then
+        LOG_TO_STDOUT=1
+    else
+        LOG_FILE=$(mktemp "/tmp/trace-process.XXXXXX.log")
+    fi
+fi
+if [[ "$LOG_TO_STDOUT" -eq 0 ]]; then
+    : > "$LOG_FILE"
+fi
+
+# --- Acquire sudo credentials upfront ---
+# Prompt once for the password before starting the process, so the
+# process's stdout/stdin are not interleaved with a sudo prompt.
+echo "[trace-process] bpftrace requires root — requesting sudo credentials..."
+sudo -v
+
+# --- Child PID tracking ---
+BPFTRACE_PIDS=()
+TARGET_PID=""
+TARGET_OWNED=0
+CLEANING_UP=0
+
+# --- Cleanup ---
+cleanup() {
+    # Guard against re-entrant cleanup (e.g. EXIT firing after INT)
+    [[ "$CLEANING_UP" -eq 1 ]] && return
+    CLEANING_UP=1
+
+    echo ""
+    echo "[trace-process] Cleaning up..."
+
+    # Tracked PIDs may be root-owned (bpftrace/sudo) or user-owned
+    # (grep, when filtering is active). Try both; one will succeed.
+    for child_pid in "${BPFTRACE_PIDS[@]}"; do
+        kill "$child_pid" 2>/dev/null || sudo kill "$child_pid" 2>/dev/null || true
+    done
+
+    # We never kill the target — we only trace, we don't own its lifecycle.
+    if [[ -n "$TARGET_PID" ]] && kill -0 "$TARGET_PID" 2>/dev/null; then
+        echo "[trace-process] Process (PID $TARGET_PID) is still running."
+    fi
+
+    wait 2>/dev/null || true
+    if [[ "$LOG_TO_STDOUT" -eq 0 ]]; then
+        echo "[trace-process] Traces saved to: $LOG_FILE"
+    fi
+    echo "[trace-process] Done."
+}
+
+trap cleanup EXIT
+trap 'trap - EXIT; cleanup; exit 130' INT
+trap 'trap - EXIT; cleanup; exit 143' TERM
+trap 'trap - EXIT; cleanup; exit 131' QUIT
+trap 'trap - EXIT; cleanup; exit 134' HUP
+
+# --- Resolve target PID ---
+if [[ -n "$ATTACH_PID" ]]; then
+    # Attach mode: verify the target PID is alive
+    TARGET_PID="$ATTACH_PID"
+    if ! kill -0 "$TARGET_PID" 2>/dev/null; then
+        echo "[trace-process] Process $TARGET_PID is not running." >&2
+        exit 1
+    fi
+    echo "[trace-process] Attaching to PID: $TARGET_PID"
+else
+    # Run mode: launch the command (unprivileged)
+    TARGET_OWNED=1
+    echo "[trace-process] Starting: $*"
+    "$@" &
+    TARGET_PID=$!
+    echo "[trace-process] PID: $TARGET_PID"
+
+    # Give the process a moment to start (bpftrace needs a live PID)
+    sleep 0.2
+    if ! kill -0 "$TARGET_PID" 2>/dev/null; then
+        echo "[trace-process] Process exited immediately." >&2
+        exit 1
+    fi
+fi
+
+# --- Attach bpftrace scripts (elevated) ---
+# Each bpftrace is wrapped with stdbuf -oL to force line-buffered
+# output. This ensures lines are flushed to the log file promptly and
+# that concurrent writers don't interleave partial lines (each line
+# write is a single write() call, well under the PIPE_BUF atomic
+# guarantee of 4096 bytes on Linux).
+#
+# When outputting to stdout, we open fd 3 as a copy of stdout so that
+# backgrounded processes can write to it reliably.
+if [[ "$LOG_TO_STDOUT" -eq 1 ]]; then
+    exec 3>&1
+    OUT_REDIR="/dev/fd/3"
+else
+    OUT_REDIR="$LOG_FILE"
+fi
+
+if [[ "$TRACE_EXECS" -eq 1 ]]; then
+    echo "[trace-process] Attaching exec tracer..."
+    sudo stdbuf -oL bpftrace "$SCRIPT_DIR/trace-execs.bt" "$TARGET_PID" >> "$OUT_REDIR" 2>&1 &
+    BPFTRACE_PIDS+=($!)
+fi
+
+if [[ "$TRACE_FILES" -eq 1 ]]; then
+    echo "[trace-process] Attaching file tracer..."
+    if [[ -n "$FILE_FILTER" ]]; then
+        sudo stdbuf -oL bpftrace "$SCRIPT_DIR/trace-files.bt" "$TARGET_PID" 2>&1 \
+            | stdbuf -oL grep --line-buffered -vE "$FILE_FILTER" >> "$OUT_REDIR" &
+    else
+        sudo stdbuf -oL bpftrace "$SCRIPT_DIR/trace-files.bt" "$TARGET_PID" >> "$OUT_REDIR" 2>&1 &
+    fi
+    BPFTRACE_PIDS+=($!)
+fi
+
+if [[ "$TRACE_NETCALLS" -eq 1 ]]; then
+    echo "[trace-process] Attaching network tracer..."
+    sudo stdbuf -oL bpftrace "$SCRIPT_DIR/trace-netcalls.bt" "$TARGET_PID" >> "$OUT_REDIR" 2>&1 &
+    BPFTRACE_PIDS+=($!)
+fi
+
+if [[ "$TRACE_SUSPICIOUS" -eq 1 ]]; then
+    echo "[trace-process] Attaching suspicious ops tracer..."
+    sudo stdbuf -oL bpftrace "$SCRIPT_DIR/trace-suspicious.bt" "$TARGET_PID" >> "$OUT_REDIR" 2>&1 &
+    BPFTRACE_PIDS+=($!)
+fi
+
+if [[ ${#BPFTRACE_PIDS[@]} -eq 0 ]]; then
+    echo "[trace-process] All tracers disabled, nothing to do." >&2
+    exit 1
+fi
+
+echo "[trace-process] ${#BPFTRACE_PIDS[@]} tracer(s) attached."
+if [[ "$LOG_TO_STDOUT" -eq 0 ]]; then
+    echo "[trace-process] Traces: $LOG_FILE"
+    echo "[trace-process] Follow live with: tail -f $LOG_FILE"
+fi
+echo ""
+
+# --- Wait for the process to exit, then tear down ---
+if [[ "$TARGET_OWNED" -eq 1 ]]; then
+    # We spawned the process — wait(2) works on our own children
+    wait "$TARGET_PID" 2>/dev/null || true
+else
+    # Attach mode — poll since we can't wait on a foreign process
+    while kill -0 "$TARGET_PID" 2>/dev/null; do
+        sleep 1
+    done
+fi
+echo ""
+echo "[trace-process] Process (PID $TARGET_PID) exited."

--- a/coding/ai-ca-tools/trace-suspicious.bt
+++ b/coding/ai-ca-tools/trace-suspicious.bt
@@ -3,8 +3,8 @@
  * trace-suspicious.bt
  *
  * Monitor suspicious or potentially abusive operations performed by a
- * process and its descendants. Designed to catch AI coding agents
- * overstepping their boundaries.
+ * process and its descendants. Designed to catch processes performing
+ * suspicious or potentially dangerous operations.
  *
  * Categories of suspicious activity:
  *   - Credential/secret access (reading SSH keys, tokens, .env files)
@@ -25,6 +25,8 @@
  * Requires: kernel BTF support (CONFIG_DEBUG_INFO_BTF=y), bpftrace >= 0.21
  * Usage: sudo bpftrace trace-suspicious.bt <PID>
  */
+
+config { unstable_macro=enable }
 
 // Log an event with a single string detail
 macro log_event(event, detail) {
@@ -57,7 +59,7 @@ tracepoint:sched:sched_process_fork
 // ========================================================================
 // Credential / secret access
 // ========================================================================
-// An AI coding agent should not be reading SSH private keys, cloud
+// The traced process should not be reading SSH private keys, cloud
 // credentials, API tokens, or password files. Fires on openat() of paths
 // matching known sensitive locations.
 
@@ -72,7 +74,7 @@ tracepoint:syscalls:sys_enter_openat
 
 // --- Credential / secret files (1/2) ---
 // SSH keys, GPG keyrings, cloud credentials, GitHub CLI tokens.
-// A coding agent has no business reading these.
+// The traced process has no business reading these.
 tracepoint:syscalls:sys_exit_openat
 /@open_path[tid] != ""/
 {
@@ -101,7 +103,7 @@ tracepoint:syscalls:sys_exit_openat
 
 // --- Persistence: cron / systemd writes ---
 // Writing to cron or systemd directories installs commands that persist
-// and run after the agent exits.
+// and run after the process exits.
 tracepoint:syscalls:sys_exit_openat
 /@open_write[tid]/
 {
@@ -115,7 +117,7 @@ tracepoint:syscalls:sys_exit_openat
 }
 
 // --- Persistence: shell startup file writes ---
-// Modifying .bashrc, .zshrc, .profile etc. lets an agent inject commands
+// Modifying .bashrc, .zshrc, .profile etc. lets a process inject commands
 // that run every time the user opens a shell.
 tracepoint:syscalls:sys_exit_openat
 /@open_write[tid]/
@@ -135,8 +137,8 @@ tracepoint:syscalls:sys_exit_openat
 // ========================================================================
 // Privilege escalation
 // ========================================================================
-// A coding agent should never need to change its user/group identity or
-// modify its process capabilities.
+// The traced process should never need to change its user/group identity
+// or modify its process capabilities.
 
 // setuid / setgid — attempt to change effective user or group ID.
 // Used legitimately by login/su/sudo, never by a coding assistant.
@@ -189,8 +191,8 @@ tracepoint:syscalls:sys_enter_capset
 // ========================================================================
 
 // ptrace — attach to another process for debugging or code injection.
-// This is how debuggers and process injectors work. An AI agent has no
-// legitimate reason to ptrace anything.
+// This is how debuggers and process injectors work. The traced process
+// has no legitimate reason to ptrace anything.
 tracepoint:syscalls:sys_enter_ptrace
 /@watched[(int64)pid]/
 {
@@ -234,7 +236,7 @@ tracepoint:syscalls:sys_enter_finit_module
 }
 
 // sethostname / setdomainname — changing the system's identity is not
-// something a coding agent should ever do.
+// something the traced process should ever do.
 tracepoint:syscalls:sys_enter_sethostname
 /@watched[(int64)pid]/
 {
@@ -275,7 +277,7 @@ tracepoint:syscalls:sys_enter_socket
 // ========================================================================
 // Listening sockets / reverse shells
 // ========================================================================
-// An AI coding agent should not be opening listening sockets. This is a
+// The traced process should not be opening listening sockets. This is a
 // common pattern for reverse shells and C2 channels.
 
 // bind — binding to a network address to accept incoming connections.
@@ -391,7 +393,7 @@ tracepoint:syscalls:sys_enter_prctl
 }
 
 // seccomp — installing seccomp filters could block tracing or
-// monitoring of the agent process itself.
+// monitoring of the traced process itself.
 tracepoint:syscalls:sys_enter_seccomp
 /@watched[(int64)pid]/
 {
@@ -411,7 +413,7 @@ tracepoint:syscalls:sys_enter_personality
 }
 
 // userfaultfd — used in kernel race-condition exploits. No legitimate
-// use for a coding agent.
+// use for the traced process.
 tracepoint:syscalls:sys_enter_userfaultfd
 /@watched[(int64)pid]/
 {
@@ -460,7 +462,7 @@ tracepoint:syscalls:sys_enter_keyctl
 // Destructive system actions
 // ========================================================================
 
-// reboot — no agent should ever reboot the system.
+// reboot — no traced process should ever reboot the system.
 tracepoint:syscalls:sys_enter_reboot
 /@watched[(int64)pid]/
 {
@@ -484,7 +486,7 @@ tracepoint:syscalls:sys_enter_kill
 // ========================================================================
 
 // fchmodat with setuid (04000) or setgid (02000) bits — creating setuid
-// binaries is a classic privilege escalation technique. An agent could
+// binaries is a classic privilege escalation technique. A process could
 // compile a helper binary and make it setuid-root.
 tracepoint:syscalls:sys_enter_fchmodat
 /@watched[(int64)pid] && (args->mode & 06000)/


### PR DESCRIPTION
Add trace-process.sh, a wrapper that launches or attaches to a process and runs bpftrace scripts in parallel with sudo, log management, selective tracer disabling, and file-tracer output filtering. In attach mode (-p), traces default to stdout instead of a log file.

Add process-specific config files (confs/) for popular AI coding agents: Claude Code, Codex, Aider, Cline, Goose, Continue, and OpenHands.