### PR TITLE
[coding] Fix typo, broken logic and factorise code in process-supervior bpftrace scripts

### DIFF
--- a/coding/process-supervisor/trace-execs.bt
+++ b/coding/process-supervisor/trace-execs.bt
@@ -8,6 +8,12 @@
  * Usage: sudo bpftrace monitor_subprocesses.bt <PID>
  */
 
+config = { unstable_macro=enable; }
+
+// Timestamp: HH:MM:SS string and milliseconds within the current second
+macro ts_str(t) { strftime("%H:%M:%S", t) }
+macro ts_ms(t)  { (t % 1000000000) / 1000000 }
+
 BEGIN
 {
     if ($1 == 0) {
@@ -36,9 +42,8 @@ tracepoint:sched:sched_process_fork
 tracepoint:syscalls:sys_enter_execve
 /(@watched[(int64)pid])/
 {
-    printf("%s.%03d      %-10s ",
-        strftime("%H:%M:%S", nsecs), (nsecs % 1000000000) / 1000000,
-        "EXEC");
+    $t = nsecs;
+    printf("%s.%03d      %-10s ", ts_str($t), ts_ms($t), "EXEC");
     join(args->argv);
 }
 

--- a/coding/process-supervisor/trace-files.bt
+++ b/coding/process-supervisor/trace-files.bt
@@ -9,6 +9,12 @@
  * Usage: sudo bpftrace trace-files.bt <PID>
  */
 
+config = { unstable_macro=enable; }
+
+// Timestamp: HH:MM:SS string and milliseconds within the current second
+macro ts_str(t) { strftime("%H:%M:%S", t) }
+macro ts_ms(t)  { (t % 1000000000) / 1000000 }
+
 BEGIN
 {
     if ($1 == 0) {
@@ -42,22 +48,19 @@ tracepoint:syscalls:sys_enter_openat
 tracepoint:syscalls:sys_exit_openat
 /@open_path[tid] != ""/
 {
-    $ms = (nsecs % 1000000000) / 1000000;
+    $t = nsecs;
     $flags = @open_flags[tid];
     $path = @open_path[tid];
 
     if ($flags & 0x40) {
         // O_CREAT
-        printf("%s.%03d      %-10s %s\n",
-            strftime("%H:%M:%S", nsecs), $ms, "CREATE", $path);
+        printf("%s.%03d      %-10s %s\n", ts_str($t), ts_ms($t), "CREATE", $path);
     } else if (($flags & 3) > 0) {
         // O_WRONLY (1) or O_RDWR (2)
-        printf("%s.%03d      %-10s %s\n",
-            strftime("%H:%M:%S", nsecs), $ms, "OPEN_W", $path);
+        printf("%s.%03d      %-10s %s\n", ts_str($t), ts_ms($t), "OPEN_W", $path);
     } else {
         // O_RDONLY (0)
-        printf("%s.%03d      %-10s %s\n",
-            strftime("%H:%M:%S", nsecs), $ms, "OPEN_R", $path);
+        printf("%s.%03d      %-10s %s\n", ts_str($t), ts_ms($t), "OPEN_R", $path);
     }
 
     // Map fd to path for subsequent read/write tracking
@@ -74,18 +77,18 @@ tracepoint:syscalls:sys_exit_openat
 tracepoint:syscalls:sys_enter_read
 /@watched[(int64)pid] && @fd_to_path[pid, (int64)args->fd] != ""/
 {
-    $ms = (nsecs % 1000000000) / 1000000;
+    $t = nsecs;
     printf("%s.%03d      %-10s %s (%d bytes)\n",
-        strftime("%H:%M:%S", nsecs), $ms, "READ",
+        ts_str($t), ts_ms($t), "READ",
         @fd_to_path[pid, (int64)args->fd], args->count);
 }
 
 tracepoint:syscalls:sys_enter_write
 /@watched[(int64)pid] && @fd_to_path[pid, (int64)args->fd] != ""/
 {
-    $ms = (nsecs % 1000000000) / 1000000;
+    $t = nsecs;
     printf("%s.%03d      %-10s %s (%d bytes)\n",
-        strftime("%H:%M:%S", nsecs), $ms, "WRITE",
+        ts_str($t), ts_ms($t), "WRITE",
         @fd_to_path[pid, (int64)args->fd], args->count);
 }
 
@@ -102,9 +105,9 @@ tracepoint:syscalls:sys_enter_close
 tracepoint:syscalls:sys_enter_mkdirat
 /@watched[(int64)pid]/
 {
-    $ms = (nsecs % 1000000000) / 1000000;
+    $t = nsecs;
     printf("%s.%03d      %-10s %s (mode %o)\n",
-        strftime("%H:%M:%S", nsecs), $ms, "MKDIR",
+        ts_str($t), ts_ms($t), "MKDIR",
         str(args->pathname), args->mode);
 }
 
@@ -113,10 +116,9 @@ tracepoint:syscalls:sys_enter_mkdirat
 tracepoint:syscalls:sys_enter_unlinkat
 /@watched[(int64)pid]/
 {
-    $ms = (nsecs % 1000000000) / 1000000;
+    $t = nsecs;
     printf("%s.%03d      %-10s %s\n",
-        strftime("%H:%M:%S", nsecs), $ms, "DELETE",
-        str(args->pathname));
+        ts_str($t), ts_ms($t), "DELETE", str(args->pathname));
 }
 
 // --- File rename ---
@@ -124,9 +126,9 @@ tracepoint:syscalls:sys_enter_unlinkat
 tracepoint:syscalls:sys_enter_renameat2
 /@watched[(int64)pid]/
 {
-    $ms = (nsecs % 1000000000) / 1000000;
+    $t = nsecs;
     printf("%s.%03d      %-10s %s -> %s\n",
-        strftime("%H:%M:%S", nsecs), $ms, "RENAME",
+        ts_str($t), ts_ms($t), "RENAME",
         str(args->oldname), str(args->newname));
 }
 
@@ -135,9 +137,9 @@ tracepoint:syscalls:sys_enter_renameat2
 tracepoint:syscalls:sys_enter_fchmodat
 /@watched[(int64)pid]/
 {
-    $ms = (nsecs % 1000000000) / 1000000;
+    $t = nsecs;
     printf("%s.%03d      %-10s %s (mode %o)\n",
-        strftime("%H:%M:%S", nsecs), $ms, "CHMOD",
+        ts_str($t), ts_ms($t), "CHMOD",
         str(args->filename), args->mode);
 }
 
@@ -146,9 +148,9 @@ tracepoint:syscalls:sys_enter_fchmodat
 tracepoint:syscalls:sys_enter_fchownat
 /@watched[(int64)pid]/
 {
-    $ms = (nsecs % 1000000000) / 1000000;
+    $t = nsecs;
     printf("%s.%03d      %-10s %s (uid %d, gid %d)\n",
-        strftime("%H:%M:%S", nsecs), $ms, "CHOWN",
+        ts_str($t), ts_ms($t), "CHOWN",
         str(args->filename), args->user, args->group);
 }
 

--- a/coding/process-supervisor/trace-netcalls.bt
+++ b/coding/process-supervisor/trace-netcalls.bt
@@ -16,108 +16,117 @@
  * Usage: sudo bpftrace trace-netcalls.bt <PID>
  */
 
-config { unstable_macro=enable }
+config = { unstable_macro=enable; }
 
 // --- Macros ---
+
+// Timestamp: HH:MM:SS string and milliseconds within the current second
+macro ts_str(t) { strftime("%H:%M:%S", t) }
+macro ts_ms(t)  { (t % 1000000000) / 1000000 }
 
 // Network to host byte order for 16-bit values
 macro ntohs(raw) { ((raw >> 8) | ((raw & 0xff) << 8)) }
 
-// Print a TCP event using sock struct fields (IPv6 only, IPv4 uses aggregation)
-macro log_sock_event_v6($sk, event, size) {
-    $raw = $sk->__sk_common.skc_dport;
-    $dport = ($raw >> 8) | (($raw & 0xff) << 8);
-    $ms = (nsecs % 1000000000) / 1000000;
+// Print a TCP event using sock struct fields (IPv6 only, IPv4 uses aggregation).
+macro log_sock_event_v6($sk, event, size, $t) {
+    $dport_v6 = ntohs($sk->__sk_common.skc_dport);
     printf("%s.%03d      %-10s [%s]:%d (%d bytes)\n",
-        strftime("%H:%M:%S", nsecs), $ms,
-        event, ntop(10, $sk->__sk_common.skc_v6_daddr.in6_u.u6_addr8), $dport, size);
+        ts_str($t), ts_ms($t), event,
+        ntop(10, $sk->__sk_common.skc_v6_daddr.in6_u.u6_addr8), $dport_v6, size);
 }
 
-// Print an aggregated IPv4 TCP event (no map access — all values passed as args)
-macro print_agg($time, $type, $ip, $dport, $host, $bytes, $count) {
-    $ms = ($time % 1000000000) / 1000000;
-    if ($host != "") {
-        if ($count > 1) {
+// Print an aggregated IPv4 TCP event — all values passed as args.
+// Uses a stored timestamp rather than current nsecs.
+macro print_agg(time, type, ip, dport, host, bytes, count) {
+    if (host != "") {
+        if (count > 1) {
             printf("%s.%03d      %-10s %s:%d [%s] (%d bytes, %d calls)\n",
-                strftime("%H:%M:%S", $time), $ms, $type,
-                $ip, $dport, $host, $bytes, $count);
+                ts_str(time), ts_ms(time), type,
+                ip, dport, host, bytes, count);
         } else {
             printf("%s.%03d      %-10s %s:%d [%s] (%d bytes)\n",
-                strftime("%H:%M:%S", $time), $ms, $type,
-                $ip, $dport, $host, $bytes);
+                ts_str(time), ts_ms(time), type,
+                ip, dport, host, bytes);
         }
     } else {
-        if ($count > 1) {
+        if (count > 1) {
             printf("%s.%03d      %-10s %s:%d (%d bytes, %d calls)\n",
-                strftime("%H:%M:%S", $time), $ms, $type,
-                $ip, $dport, $bytes, $count);
+                ts_str(time), ts_ms(time), type,
+                ip, dport, bytes, count);
         } else {
             printf("%s.%03d      %-10s %s:%d (%d bytes)\n",
-                strftime("%H:%M:%S", $time), $ms, $type,
-                $ip, $dport, $bytes);
+                ts_str(time), ts_ms(time), type,
+                ip, dport, bytes);
         }
+    }
+}
+
+// Flush pending TCP aggregation for the current pid
+macro flush_agg(@ac, @at, @atm, @ai, @adp, @hbi, @ab) {
+    if (@ac[pid] > 0) {
+        $fa_type = "TX_TCP";
+        if (@at[pid] != 1) { $fa_type = "RX_TCP"; }
+        print_agg(@atm[pid], $fa_type, @ai[pid], @adp[pid],
+            @hbi[@ai[pid]], @ab[pid], @ac[pid]);
+        @ac[pid] = 0;
     }
 }
 
 // Print an IPv4 UDP event (DNS or TX_UDP).
 // Resolves destination from msg_name (unconnected) or sock (connected).
 // msg_name is kernel-space at kprobe:udp_sendmsg (copied by move_addr_to_kernel).
-macro log_udp4($sk, $msg, size) {
-    $ms = (nsecs % 1000000000) / 1000000;
+macro log_udp4($sk, $msg, size, $t) {
     if ($msg->msg_name != 0) {
-        $name = (uint64)$msg->msg_name;
-        $port = (*(uint8 *)($name + 2) << 8) | *(uint8 *)($name + 3);
-        if ($port == 53) {
+        $name_u4 = (uint64)$msg->msg_name;
+        $port_u4 = (*(uint8 *)($name_u4 + 2) << 8) | *(uint8 *)($name_u4 + 3);
+        if ($port_u4 == 53) {
             printf("%s.%03d      %-10s %s:53 (%d bytes)\n",
-                strftime("%H:%M:%S", nsecs), $ms, "DNS",
-                ntop(2, *(uint32 *)($name + 4)), size);
+                ts_str($t), ts_ms($t), "DNS",
+                ntop(2, *(uint32 *)($name_u4 + 4)), size);
         } else {
             printf("%s.%03d      %-10s %s:%d (%d bytes)\n",
-                strftime("%H:%M:%S", nsecs), $ms, "TX_UDP",
-                ntop(2, *(uint32 *)($name + 4)), $port, size);
+                ts_str($t), ts_ms($t), "TX_UDP",
+                ntop(2, *(uint32 *)($name_u4 + 4)), $port_u4, size);
         }
     } else {
-        $raw = $sk->__sk_common.skc_dport;
-        $port2 = ($raw >> 8) | (($raw & 0xff) << 8);
-        if ($port2 == 53) {
+        $port_u4c = ntohs($sk->__sk_common.skc_dport);
+        if ($port_u4c == 53) {
             printf("%s.%03d      %-10s %s:53 (%d bytes)\n",
-                strftime("%H:%M:%S", nsecs), $ms, "DNS",
+                ts_str($t), ts_ms($t), "DNS",
                 ntop(2, $sk->__sk_common.skc_daddr), size);
         } else {
             printf("%s.%03d      %-10s %s:%d (%d bytes)\n",
-                strftime("%H:%M:%S", nsecs), $ms, "TX_UDP",
-                ntop(2, $sk->__sk_common.skc_daddr), $port2, size);
+                ts_str($t), ts_ms($t), "TX_UDP",
+                ntop(2, $sk->__sk_common.skc_daddr), $port_u4c, size);
         }
     }
 }
 
-// Print an IPv6 UDP event (DNS or TX_UDP)
-macro log_udp6($sk, $msg, size) {
-    $ms = (nsecs % 1000000000) / 1000000;
+// Print an IPv6 UDP event (DNS or TX_UDP).
+macro log_udp6($sk, $msg, size, $t) {
     if ($msg->msg_name != 0) {
-        $name = (uint64)$msg->msg_name;
-        $port = (*(uint8 *)($name + 2) << 8) | *(uint8 *)($name + 3);
+        $name_u6 = (uint64)$msg->msg_name;
+        $port_u6 = (*(uint8 *)($name_u6 + 2) << 8) | *(uint8 *)($name_u6 + 3);
         // sockaddr_in6: sin6_addr at offset 8, 16 bytes
-        if ($port == 53) {
+        if ($port_u6 == 53) {
             printf("%s.%03d      %-10s [%s]:53 (%d bytes)\n",
-                strftime("%H:%M:%S", nsecs), $ms, "DNS",
-                ntop(10, $name + 8), size);
+                ts_str($t), ts_ms($t), "DNS",
+                ntop(10, $name_u6 + 8), size);
         } else {
             printf("%s.%03d      %-10s [%s]:%d (%d bytes)\n",
-                strftime("%H:%M:%S", nsecs), $ms, "TX_UDP",
-                ntop(10, $name + 8), $port, size);
+                ts_str($t), ts_ms($t), "TX_UDP",
+                ntop(10, $name_u6 + 8), $port_u6, size);
         }
     } else {
-        $raw = $sk->__sk_common.skc_dport;
-        $port2 = ($raw >> 8) | (($raw & 0xff) << 8);
-        if ($port2 == 53) {
+        $port_u6c = ntohs($sk->__sk_common.skc_dport);
+        if ($port_u6c == 53) {
             printf("%s.%03d      %-10s [%s]:53 (%d bytes)\n",
-                strftime("%H:%M:%S", nsecs), $ms, "DNS",
+                ts_str($t), ts_ms($t), "DNS",
                 ntop(10, $sk->__sk_common.skc_v6_daddr.in6_u.u6_addr8), size);
         } else {
             printf("%s.%03d      %-10s [%s]:%d (%d bytes)\n",
-                strftime("%H:%M:%S", nsecs), $ms, "TX_UDP",
-                ntop(10, $sk->__sk_common.skc_v6_daddr.in6_u.u6_addr8), $port2, size);
+                ts_str($t), ts_ms($t), "TX_UDP",
+                ntop(10, $sk->__sk_common.skc_v6_daddr.in6_u.u6_addr8), $port_u6c, size);
         }
     }
 }
@@ -154,24 +163,11 @@ tracepoint:sched:sched_process_fork
 uprobe:/usr/lib/libc.so.6:getaddrinfo
 /@watched[(int64)pid]/
 {
-    // Flush pending aggregation
-    if (@agg_count[pid] > 0) {
-        $a_daddr = @agg_daddr[pid];
-        $a_dport = @agg_dport[pid];
-        $a_bytes = @agg_bytes[pid];
-        $a_count = @agg_count[pid];
-        $a_time = @agg_time[pid];
-        $a_host = @host_by_ip[@agg_ip[pid]];
-        $a_type = "TX_TCP";
-        if (@agg_type[pid] != 1) { $a_type = "RX_TCP"; }
-        $a_ip = @agg_ip[pid];
-        print_agg($a_time, $a_type, $a_ip, $a_dport, $a_host, $a_bytes, $a_count);
-        @agg_count[pid] = 0;
-    }
+    flush_agg(@agg_count, @agg_type, @agg_time, @agg_ip, @agg_dport, @host_by_ip, @agg_bytes);
 
+    $t = nsecs;
     printf("%s.%03d      %-10s %s\n",
-        strftime("%H:%M:%S", nsecs), (nsecs % 1000000000) / 1000000,
-        "RESOLVE", str(arg0));
+        ts_str($t), ts_ms($t), "RESOLVE", str(arg0));
     @resolve_host[pid] = str(arg0);
 }
 
@@ -179,22 +175,9 @@ uprobe:/usr/lib/libc.so.6:getaddrinfo
 tracepoint:sock:inet_sock_set_state
 /args->newstate == 2 && @watched[(int64)pid]/
 {
-    // Flush pending aggregation
-    if (@agg_count[pid] > 0) {
-        $a_daddr = @agg_daddr[pid];
-        $a_dport = @agg_dport[pid];
-        $a_bytes = @agg_bytes[pid];
-        $a_count = @agg_count[pid];
-        $a_time = @agg_time[pid];
-        $a_host = @host_by_ip[@agg_ip[pid]];
-        $a_type = "TX_TCP";
-        if (@agg_type[pid] != 1) { $a_type = "RX_TCP"; }
-        $a_ip = @agg_ip[pid];
-        print_agg($a_time, $a_type, $a_ip, $a_dport, $a_host, $a_bytes, $a_count);
-        @agg_count[pid] = 0;
-    }
+    flush_agg(@agg_count, @agg_type, @agg_time, @agg_ip, @agg_dport, @host_by_ip, @agg_bytes);
 
-    $ms = (nsecs % 1000000000) / 1000000;
+    $t = nsecs;
     if (args->family == 2) {
         $daddr = (uint32)args->daddr[0] | ((uint32)args->daddr[1] << 8)
             | ((uint32)args->daddr[2] << 16) | ((uint32)args->daddr[3] << 24);
@@ -204,19 +187,18 @@ tracepoint:sock:inet_sock_set_state
         }
         if (@ip_to_host[$daddr] != "") {
             printf("%s.%03d      %-10s %s:%d [%s]\n",
-                strftime("%H:%M:%S", nsecs), $ms,
-                "CONNECT", ntop(2, args->daddr), args->dport,
-                @ip_to_host[$daddr]);
+                ts_str($t), ts_ms($t), "CONNECT",
+                ntop(2, args->daddr), args->dport, @ip_to_host[$daddr]);
         } else {
             printf("%s.%03d      %-10s %s:%d\n",
-                strftime("%H:%M:%S", nsecs), $ms,
-                "CONNECT", ntop(2, args->daddr), args->dport);
+                ts_str($t), ts_ms($t), "CONNECT",
+                ntop(2, args->daddr), args->dport);
         }
     }
     else if (args->family == 10) {
         printf("%s.%03d      %-10s [%s]:%d\n",
-            strftime("%H:%M:%S", nsecs), $ms,
-            "CONNECT", ntop(10, args->daddr_v6), args->dport);
+            ts_str($t), ts_ms($t), "CONNECT",
+            ntop(10, args->daddr_v6), args->dport);
     }
 }
 
@@ -224,38 +206,24 @@ tracepoint:sock:inet_sock_set_state
 tracepoint:sock:inet_sock_set_state
 /args->newstate == 7 && @watched[(int64)pid]/
 {
-    // Flush pending aggregation
-    if (@agg_count[pid] > 0) {
-        $a_daddr = @agg_daddr[pid];
-        $a_dport = @agg_dport[pid];
-        $a_bytes = @agg_bytes[pid];
-        $a_count = @agg_count[pid];
-        $a_time = @agg_time[pid];
-        $a_host = @host_by_ip[@agg_ip[pid]];
-        $a_type = "TX_TCP";
-        if (@agg_type[pid] != 1) { $a_type = "RX_TCP"; }
-        $a_ip = @agg_ip[pid];
-        print_agg($a_time, $a_type, $a_ip, $a_dport, $a_host, $a_bytes, $a_count);
-        @agg_count[pid] = 0;
-    }
+    flush_agg(@agg_count, @agg_type, @agg_time, @agg_ip, @agg_dport, @host_by_ip, @agg_bytes);
 
-    $ms = (nsecs % 1000000000) / 1000000;
+    $t = nsecs;
     if (args->family == 2) {
         $ip = ntop(2, args->daddr);
         if (@host_by_ip[$ip] != "") {
             printf("%s.%03d      %-10s %s:%d [%s]\n",
-                strftime("%H:%M:%S", nsecs), $ms,
-                "CLOSE", $ip, args->dport, @host_by_ip[$ip]);
+                ts_str($t), ts_ms($t), "CLOSE",
+                $ip, args->dport, @host_by_ip[$ip]);
         } else {
             printf("%s.%03d      %-10s %s:%d\n",
-                strftime("%H:%M:%S", nsecs), $ms,
-                "CLOSE", $ip, args->dport);
+                ts_str($t), ts_ms($t), "CLOSE", $ip, args->dport);
         }
     }
     else if (args->family == 10) {
         printf("%s.%03d      %-10s [%s]:%d\n",
-            strftime("%H:%M:%S", nsecs), $ms,
-            "CLOSE", ntop(10, args->daddr_v6), args->dport);
+            ts_str($t), ts_ms($t), "CLOSE",
+            ntop(10, args->daddr_v6), args->dport);
     }
 }
 
@@ -266,14 +234,14 @@ tracepoint:sock:inet_sock_set_state
 kprobe:tcp_sendmsg
 /@watched[(int64)pid]/
 {
+    $t = nsecs;
     $sk = (struct sock *)arg0;
     $family = $sk->__sk_common.skc_family;
     $size = (uint64)arg2;
 
     if ($family == 2) {
         $daddr = $sk->__sk_common.skc_daddr;
-        $raw = $sk->__sk_common.skc_dport;
-        $dport = ($raw >> 8) | (($raw & 0xff) << 8);
+        $dport = ntohs($sk->__sk_common.skc_dport);
 
         if (@agg_type[pid] == 1 && @agg_daddr[pid] == $daddr && @agg_dport[pid] == $dport) {
             // Same connection, same direction: accumulate
@@ -281,48 +249,25 @@ kprobe:tcp_sendmsg
             @agg_count[pid]++;
         } else {
             // Different: flush previous, start new
-            if (@agg_count[pid] > 0) {
-                $a_daddr = @agg_daddr[pid];
-                $a_dport = @agg_dport[pid];
-                $a_bytes = @agg_bytes[pid];
-                $a_count = @agg_count[pid];
-                $a_time = @agg_time[pid];
-                $a_host = @host_by_ip[@agg_ip[pid]];
-                $a_type = "TX_TCP";
-                if (@agg_type[pid] != 1) { $a_type = "RX_TCP"; }
-                $a_ip = @agg_ip[pid];
-                print_agg($a_time, $a_type, $a_ip, $a_dport, $a_host, $a_bytes, $a_count);
-            }
+            flush_agg(@agg_count, @agg_type, @agg_time, @agg_ip, @agg_dport, @host_by_ip, @agg_bytes);
             @agg_type[pid] = 1;
             @agg_daddr[pid] = $daddr;
             @agg_ip[pid] = ntop(2, $daddr);
             @agg_dport[pid] = $dport;
             @agg_bytes[pid] = $size;
             @agg_count[pid] = 1;
-            @agg_time[pid] = nsecs;
+            @agg_time[pid] = $t;
         }
     } else if ($family == 10) {
-        // Flush pending IPv4 aggregation, print IPv6 immediately
-        if (@agg_count[pid] > 0) {
-            $a_daddr = @agg_daddr[pid];
-            $a_dport = @agg_dport[pid];
-            $a_bytes = @agg_bytes[pid];
-            $a_count = @agg_count[pid];
-            $a_time = @agg_time[pid];
-            $a_host = @host_by_ip[@agg_ip[pid]];
-            $a_type = "TX_TCP";
-            if (@agg_type[pid] != 1) { $a_type = "RX_TCP"; }
-            $a_ip = @agg_ip[pid];
-            print_agg($a_time, $a_type, $a_ip, $a_dport, $a_host, $a_bytes, $a_count);
-            @agg_count[pid] = 0;
-        }
-        log_sock_event_v6($sk, "TX_TCP", $size)
+        flush_agg(@agg_count, @agg_type, @agg_time, @agg_ip, @agg_dport, @host_by_ip, @agg_bytes);
+        log_sock_event_v6($sk, "TX_TCP", $size, $t);
     }
 }
 
 kprobe:tcp_cleanup_rbuf
 /@watched[(int64)pid]/
 {
+    $t = nsecs;
     $sk = (struct sock *)arg0;
     $sz = (int64)arg1;
     if ($sz > 0) {
@@ -330,48 +275,24 @@ kprobe:tcp_cleanup_rbuf
 
         if ($family == 2) {
             $daddr = $sk->__sk_common.skc_daddr;
-            $raw = $sk->__sk_common.skc_dport;
-            $dport = ($raw >> 8) | (($raw & 0xff) << 8);
+            $dport = ntohs($sk->__sk_common.skc_dport);
 
             if (@agg_type[pid] == 2 && @agg_daddr[pid] == $daddr && @agg_dport[pid] == $dport) {
                 @agg_bytes[pid] += (uint64)$sz;
                 @agg_count[pid]++;
             } else {
-                if (@agg_count[pid] > 0) {
-                    $a_daddr = @agg_daddr[pid];
-                    $a_dport = @agg_dport[pid];
-                    $a_bytes = @agg_bytes[pid];
-                    $a_count = @agg_count[pid];
-                    $a_time = @agg_time[pid];
-                    $a_host = @host_by_ip[@agg_ip[pid]];
-                    $a_type = "TX_TCP";
-                    if (@agg_type[pid] != 1) { $a_type = "RX_TCP"; }
-                    $a_ip = @agg_ip[pid];
-                    print_agg($a_time, $a_type, $a_ip, $a_dport, $a_host, $a_bytes, $a_count);
-                }
+                flush_agg(@agg_count, @agg_type, @agg_time, @agg_ip, @agg_dport, @host_by_ip, @agg_bytes);
                 @agg_type[pid] = 2;
                 @agg_daddr[pid] = $daddr;
                 @agg_ip[pid] = ntop(2, $daddr);
                 @agg_dport[pid] = $dport;
                 @agg_bytes[pid] = (uint64)$sz;
                 @agg_count[pid] = 1;
-                @agg_time[pid] = nsecs;
+                @agg_time[pid] = $t;
             }
         } else if ($family == 10) {
-            if (@agg_count[pid] > 0) {
-                $a_daddr = @agg_daddr[pid];
-                $a_dport = @agg_dport[pid];
-                $a_bytes = @agg_bytes[pid];
-                $a_count = @agg_count[pid];
-                $a_time = @agg_time[pid];
-                $a_host = @host_by_ip[@agg_ip[pid]];
-                $a_type = "TX_TCP";
-                if (@agg_type[pid] != 1) { $a_type = "RX_TCP"; }
-                $a_ip = @agg_ip[pid];
-                print_agg($a_time, $a_type, $a_ip, $a_dport, $a_host, $a_bytes, $a_count);
-                @agg_count[pid] = 0;
-            }
-            log_sock_event_v6($sk, "RX_TCP", $sz)
+            flush_agg(@agg_count, @agg_type, @agg_time, @agg_ip, @agg_dport, @host_by_ip, @agg_bytes);
+            log_sock_event_v6($sk, "RX_TCP", $sz, $t);
         }
     }
 }
@@ -379,47 +300,23 @@ kprobe:tcp_cleanup_rbuf
 kprobe:udp_sendmsg
 /@watched[(int64)pid]/
 {
-    // Flush pending aggregation
-    if (@agg_count[pid] > 0) {
-        $a_daddr = @agg_daddr[pid];
-        $a_dport = @agg_dport[pid];
-        $a_bytes = @agg_bytes[pid];
-        $a_count = @agg_count[pid];
-        $a_time = @agg_time[pid];
-        $a_host = @host_by_ip[@agg_ip[pid]];
-        $a_type = "TX_TCP";
-        if (@agg_type[pid] != 1) { $a_type = "RX_TCP"; }
-        $a_ip = @agg_ip[pid];
-        print_agg($a_time, $a_type, $a_ip, $a_dport, $a_host, $a_bytes, $a_count);
-        @agg_count[pid] = 0;
-    }
+    flush_agg(@agg_count, @agg_type, @agg_time, @agg_ip, @agg_dport, @host_by_ip, @agg_bytes);
 
+    $t = nsecs;
     $sk = (struct sock *)arg0;
     $msg = (struct msghdr *)arg1;
-    log_udp4($sk, $msg, (uint64)arg2)
+    log_udp4($sk, $msg, (uint64)arg2, $t);
 }
 
 kprobe:udpv6_sendmsg
 /@watched[(int64)pid]/
 {
-    // Flush pending aggregation
-    if (@agg_count[pid] > 0) {
-        $a_daddr = @agg_daddr[pid];
-        $a_dport = @agg_dport[pid];
-        $a_bytes = @agg_bytes[pid];
-        $a_count = @agg_count[pid];
-        $a_time = @agg_time[pid];
-        $a_host = @host_by_ip[@agg_ip[pid]];
-        $a_type = "TX_TCP";
-        if (@agg_type[pid] != 1) { $a_type = "RX_TCP"; }
-        $a_ip = @agg_ip[pid];
-        print_agg($a_time, $a_type, $a_ip, $a_dport, $a_host, $a_bytes, $a_count);
-        @agg_count[pid] = 0;
-    }
+    flush_agg(@agg_count, @agg_type, @agg_time, @agg_ip, @agg_dport, @host_by_ip, @agg_bytes);
 
+    $t = nsecs;
     $sk = (struct sock *)arg0;
     $msg = (struct msghdr *)arg1;
-    log_udp6($sk, $msg, (uint64)arg2)
+    log_udp6($sk, $msg, (uint64)arg2, $t);
 }
 
 // Stop watching processes that have exited (only when main thread exits)
@@ -427,20 +324,7 @@ tracepoint:sched:sched_process_exit
 /(@watched[(int64)pid]) && tid == pid/
 {
     // Flush pending aggregation for this process
-    if (@agg_count[pid] > 0) {
-        $a_daddr = @agg_daddr[pid];
-        $a_dport = @agg_dport[pid];
-        $a_bytes = @agg_bytes[pid];
-        $a_count = @agg_count[pid];
-        $a_time = @agg_time[pid];
-        $a_host = @host_by_ip[@agg_ip[pid]];
-        $a_type = "TX_TCP";
-        if (@agg_type[pid] != 1) { $a_type = "RX_TCP"; }
-        $a_ip = @agg_ip[pid];
-        print_agg($a_time, $a_type, $a_ip, $a_dport, $a_host, $a_bytes, $a_count);
-        @agg_count[pid] = 0;
-    }
-
+    flush_agg(@agg_count, @agg_type, @agg_time, @agg_ip, @agg_dport, @host_by_ip, @agg_bytes);
     delete(@watched[(int64)pid]);
 }
 

--- a/coding/process-supervisor/trace-suspicious.bt
+++ b/coding/process-supervisor/trace-suspicious.bt
@@ -26,14 +26,11 @@
  * Usage: sudo bpftrace trace-suspicious.bt <PID>
  */
 
-config { unstable_macro=enable }
+config = { unstable_macro=enable; }
 
-// Log an event with a single string detail
-macro log_event(event, detail) {
-    printf("%s.%03d      %-10s %s\n",
-        strftime("%H:%M:%S", nsecs), (nsecs % 1000000000) / 1000000,
-        event, detail);
-}
+// Timestamp: HH:MM:SS string and milliseconds within the current second
+macro ts_str(t) { strftime("%H:%M:%S", t) }
+macro ts_ms(t)  { (t % 1000000000) / 1000000 }
 
 BEGIN
 {
@@ -72,9 +69,8 @@ tracepoint:syscalls:sys_enter_openat
     @open_write[tid] = (args->flags & 3) > 0 || (args->flags & 0x40) ? 1 : 0;
 }
 
-// --- Credential / secret files ---
-// SSH keys, GPG keyrings, cloud credentials, 
-// .env files, token/secret/credential files, etc.
+// --- Credential / secret files (1/2) ---
+// SSH keys, GPG keyrings, cloud credentials, GitHub CLI tokens.
 // The traced process has no business reading these.
 tracepoint:syscalls:sys_exit_openat
 /@open_path[tid] != ""/
@@ -85,14 +81,27 @@ tracepoint:syscalls:sys_exit_openat
         strcontains($path, ".docker/") ||
         strcontains($path, ".kube/") ||
         strcontains($path, ".aws/") ||
-        strcontains($path, ".azure/") ||
-        strcontains($path, ".env") ||
+        strcontains($path, ".azure/")) {
+        $t = nsecs;
+        printf("%s.%03d      %-10s %s\n",
+            ts_str($t), ts_ms($t), "!SECRET", $path);
+    }
+}
+
+// --- Credential / secret files (2/2) ---
+// .env files, token/secret/credential files, .netrc, /etc/shadow.
+tracepoint:syscalls:sys_exit_openat
+/@open_path[tid] != ""/
+{
+    $path = @open_path[tid];
+    if (strcontains($path, ".env") ||
         strcontains($path, "token") ||
         strcontains($path, "secret") ||
         strcontains($path, ".netrc") ||
-        strcontains($path, "/etc/shadow")
-    ) {
-        log_event("!SECRET", $path)
+        strcontains($path, "/etc/shadow")) {
+        $t = nsecs;
+        printf("%s.%03d      %-10s %s\n",
+            ts_str($t), ts_ms($t), "!SECRET", $path);
     }
 }
 
@@ -108,7 +117,9 @@ tracepoint:syscalls:sys_exit_openat
         strcontains($path, "/etc/systemd/") ||
         strcontains($path, "systemd/user/")
     ) {
-        log_event("!PERSIST", $path)
+        $t = nsecs;
+        printf("%s.%03d      %-10s %s\n",
+            ts_str($t), ts_ms($t), "!PERSIST", $path);
     }
 }
 
@@ -124,7 +135,9 @@ tracepoint:syscalls:sys_exit_openat
         strcontains($path, ".bash_profile") ||
         strcontains($path, ".zshrc")
     ) {
-        log_event("!SHRC_W", $path)
+        $t = nsecs;
+        printf("%s.%03d      %-10s %s\n",
+            ts_str($t), ts_ms($t), "!SHRC_W", $path);
     }
 
     delete(@open_path[tid]);
@@ -142,17 +155,17 @@ tracepoint:syscalls:sys_exit_openat
 tracepoint:syscalls:sys_enter_setuid
 /@watched[(int64)pid]/
 {
+    $t = nsecs;
     printf("%s.%03d      %-10s uid=%d\n",
-        strftime("%H:%M:%S", nsecs), (nsecs % 1000000000) / 1000000,
-        "!SETUID", args->uid);
+        ts_str($t), ts_ms($t), "!SETUID", args->uid);
 }
 
 tracepoint:syscalls:sys_enter_setgid
 /@watched[(int64)pid]/
 {
+    $t = nsecs;
     printf("%s.%03d      %-10s gid=%d\n",
-        strftime("%H:%M:%S", nsecs), (nsecs % 1000000000) / 1000000,
-        "!SETGID", args->gid);
+        ts_str($t), ts_ms($t), "!SETGID", args->gid);
 }
 
 // setresuid / setresgid — set real, effective, and saved user/group IDs.
@@ -160,17 +173,19 @@ tracepoint:syscalls:sys_enter_setgid
 tracepoint:syscalls:sys_enter_setresuid
 /@watched[(int64)pid]/
 {
+    $t = nsecs;
     printf("%s.%03d      %-10s ruid=%d euid=%d suid=%d\n",
-        strftime("%H:%M:%S", nsecs), (nsecs % 1000000000) / 1000000,
-        "!SETRESUID", args->ruid, args->euid, args->suid);
+        ts_str($t), ts_ms($t), "!SETRESUID",
+        args->ruid, args->euid, args->suid);
 }
 
 tracepoint:syscalls:sys_enter_setresgid
 /@watched[(int64)pid]/
 {
+    $t = nsecs;
     printf("%s.%03d      %-10s rgid=%d egid=%d sgid=%d\n",
-        strftime("%H:%M:%S", nsecs), (nsecs % 1000000000) / 1000000,
-        "!SETRESGID", args->rgid, args->egid, args->sgid);
+        ts_str($t), ts_ms($t), "!SETRESGID",
+        args->rgid, args->egid, args->sgid);
 }
 
 // capset — modify process capabilities (e.g. granting CAP_NET_RAW,
@@ -178,9 +193,9 @@ tracepoint:syscalls:sys_enter_setresgid
 tracepoint:syscalls:sys_enter_capset
 /@watched[(int64)pid]/
 {
+    $t = nsecs;
     printf("%s.%03d      %-10s pid=%d\n",
-        strftime("%H:%M:%S", nsecs), (nsecs % 1000000000) / 1000000,
-        "!CAPSET", pid);
+        ts_str($t), ts_ms($t), "!CAPSET", pid);
 }
 
 // ========================================================================
@@ -193,9 +208,9 @@ tracepoint:syscalls:sys_enter_capset
 tracepoint:syscalls:sys_enter_ptrace
 /@watched[(int64)pid]/
 {
+    $t = nsecs;
     printf("%s.%03d      %-10s request=%ld target_pid=%ld\n",
-        strftime("%H:%M:%S", nsecs), (nsecs % 1000000000) / 1000000,
-        "!PTRACE", args->request, args->pid);
+        ts_str($t), ts_ms($t), "!PTRACE", args->request, args->pid);
 }
 
 // mount / umount — mounting filesystems can be used to overlay system
@@ -203,15 +218,18 @@ tracepoint:syscalls:sys_enter_ptrace
 tracepoint:syscalls:sys_enter_mount
 /@watched[(int64)pid]/
 {
+    $t = nsecs;
     printf("%s.%03d      %-10s %s on %s type %s\n",
-        strftime("%H:%M:%S", nsecs), (nsecs % 1000000000) / 1000000,
-        "!MOUNT", str(args->dev_name), str(args->dir_name), str(args->type));
+        ts_str($t), ts_ms($t), "!MOUNT",
+        str(args->dev_name), str(args->dir_name), str(args->type));
 }
 
 tracepoint:syscalls:sys_enter_umount
 /@watched[(int64)pid]/
 {
-    log_event("!UMOUNT", str(args->name))
+    $t = nsecs;
+    printf("%s.%03d      %-10s %s\n",
+        ts_str($t), ts_ms($t), "!UMOUNT", str(args->name));
 }
 
 // init_module / finit_module — loading kernel modules gives full kernel
@@ -219,17 +237,17 @@ tracepoint:syscalls:sys_enter_umount
 tracepoint:syscalls:sys_enter_init_module
 /@watched[(int64)pid]/
 {
+    $t = nsecs;
     printf("%s.%03d      %-10s size=%lu\n",
-        strftime("%H:%M:%S", nsecs), (nsecs % 1000000000) / 1000000,
-        "!KMOD", args->len);
+        ts_str($t), ts_ms($t), "!KMOD", args->len);
 }
 
 tracepoint:syscalls:sys_enter_finit_module
 /@watched[(int64)pid]/
 {
+    $t = nsecs;
     printf("%s.%03d      %-10s fd=%d\n",
-        strftime("%H:%M:%S", nsecs), (nsecs % 1000000000) / 1000000,
-        "!KMOD", args->fd);
+        ts_str($t), ts_ms($t), "!KMOD", args->fd);
 }
 
 // sethostname / setdomainname — changing the system's identity is not
@@ -237,13 +255,17 @@ tracepoint:syscalls:sys_enter_finit_module
 tracepoint:syscalls:sys_enter_sethostname
 /@watched[(int64)pid]/
 {
-    log_event("!SETHOST", str(args->name))
+    $t = nsecs;
+    printf("%s.%03d      %-10s %s\n",
+        ts_str($t), ts_ms($t), "!SETHOST", str(args->name));
 }
 
 tracepoint:syscalls:sys_enter_setdomainname
 /@watched[(int64)pid]/
 {
-    log_event("!SETDOM", str(args->name))
+    $t = nsecs;
+    printf("%s.%03d      %-10s %s\n",
+        ts_str($t), ts_ms($t), "!SETDOM", str(args->name));
 }
 
 // ========================================================================
@@ -256,9 +278,10 @@ tracepoint:syscalls:sys_enter_setdomainname
 tracepoint:syscalls:sys_enter_memfd_create
 /@watched[(int64)pid]/
 {
+    $t = nsecs;
     printf("%s.%03d      %-10s name=%s flags=0x%x\n",
-        strftime("%H:%M:%S", nsecs), (nsecs % 1000000000) / 1000000,
-        "!MEMFD", str(args->uname), args->flags);
+        ts_str($t), ts_ms($t), "!MEMFD",
+        str(args->uname), args->flags);
 }
 
 // socket with SOCK_RAW (type 3) — raw sockets allow crafting arbitrary
@@ -266,9 +289,10 @@ tracepoint:syscalls:sys_enter_memfd_create
 tracepoint:syscalls:sys_enter_socket
 /@watched[(int64)pid] && args->type == 3/
 {
+    $t = nsecs;
     printf("%s.%03d      %-10s family=%d protocol=%d\n",
-        strftime("%H:%M:%S", nsecs), (nsecs % 1000000000) / 1000000,
-        "!RAW_SOCK", args->family, args->protocol);
+        ts_str($t), ts_ms($t), "!RAW_SOCK",
+        args->family, args->protocol);
 }
 
 // ========================================================================
@@ -281,35 +305,35 @@ tracepoint:syscalls:sys_enter_socket
 tracepoint:syscalls:sys_enter_bind
 /@watched[(int64)pid]/
 {
+    $t = nsecs;
     printf("%s.%03d      %-10s fd=%d\n",
-        strftime("%H:%M:%S", nsecs), (nsecs % 1000000000) / 1000000,
-        "!BIND", args->fd);
+        ts_str($t), ts_ms($t), "!BIND", args->fd);
 }
 
 // listen — start accepting connections on a socket.
 tracepoint:syscalls:sys_enter_listen
 /@watched[(int64)pid]/
 {
+    $t = nsecs;
     printf("%s.%03d      %-10s fd=%d backlog=%d\n",
-        strftime("%H:%M:%S", nsecs), (nsecs % 1000000000) / 1000000,
-        "!LISTEN", args->fd, args->backlog);
+        ts_str($t), ts_ms($t), "!LISTEN", args->fd, args->backlog);
 }
 
 // accept / accept4 — accepting an incoming connection.
 tracepoint:syscalls:sys_enter_accept
 /@watched[(int64)pid]/
 {
+    $t = nsecs;
     printf("%s.%03d      %-10s fd=%d\n",
-        strftime("%H:%M:%S", nsecs), (nsecs % 1000000000) / 1000000,
-        "!ACCEPT", args->fd);
+        ts_str($t), ts_ms($t), "!ACCEPT", args->fd);
 }
 
 tracepoint:syscalls:sys_enter_accept4
 /@watched[(int64)pid]/
 {
+    $t = nsecs;
     printf("%s.%03d      %-10s fd=%d\n",
-        strftime("%H:%M:%S", nsecs), (nsecs % 1000000000) / 1000000,
-        "!ACCEPT", args->fd);
+        ts_str($t), ts_ms($t), "!ACCEPT", args->fd);
 }
 
 // ========================================================================
@@ -321,17 +345,17 @@ tracepoint:syscalls:sys_enter_accept4
 tracepoint:syscalls:sys_enter_process_vm_readv
 /@watched[(int64)pid]/
 {
+    $t = nsecs;
     printf("%s.%03d      %-10s target_pid=%ld\n",
-        strftime("%H:%M:%S", nsecs), (nsecs % 1000000000) / 1000000,
-        "!VM_READ", args->pid);
+        ts_str($t), ts_ms($t), "!VM_READ", args->pid);
 }
 
 tracepoint:syscalls:sys_enter_process_vm_writev
 /@watched[(int64)pid]/
 {
+    $t = nsecs;
     printf("%s.%03d      %-10s target_pid=%ld\n",
-        strftime("%H:%M:%S", nsecs), (nsecs % 1000000000) / 1000000,
-        "!VM_WRITE", args->pid);
+        ts_str($t), ts_ms($t), "!VM_WRITE", args->pid);
 }
 
 // ========================================================================
@@ -344,23 +368,26 @@ tracepoint:syscalls:sys_enter_process_vm_writev
 tracepoint:syscalls:sys_enter_unshare
 /@watched[(int64)pid]/
 {
+    $t = nsecs;
     printf("%s.%03d      %-10s flags=0x%lx\n",
-        strftime("%H:%M:%S", nsecs), (nsecs % 1000000000) / 1000000,
-        "!UNSHARE", args->unshare_flags);
+        ts_str($t), ts_ms($t), "!UNSHARE", args->unshare_flags);
 }
 
 tracepoint:syscalls:sys_enter_chroot
 /@watched[(int64)pid]/
 {
-    log_event("!CHROOT", str(args->filename))
+    $t = nsecs;
+    printf("%s.%03d      %-10s %s\n",
+        ts_str($t), ts_ms($t), "!CHROOT", str(args->filename));
 }
 
 tracepoint:syscalls:sys_enter_pivot_root
 /@watched[(int64)pid]/
 {
+    $t = nsecs;
     printf("%s.%03d      %-10s %s -> %s\n",
-        strftime("%H:%M:%S", nsecs), (nsecs % 1000000000) / 1000000,
-        "!PIVROOT", str(args->new_root), str(args->put_old));
+        ts_str($t), ts_ms($t), "!PIVROOT",
+        str(args->new_root), str(args->put_old));
 }
 
 // ========================================================================
@@ -373,9 +400,10 @@ tracepoint:syscalls:sys_enter_pivot_root
 tracepoint:syscalls:sys_enter_mprotect
 /@watched[(int64)pid] && (args->prot & 0x4)/
 {
+    $t = nsecs;
     printf("%s.%03d      %-10s addr=0x%lx len=%lu prot=0x%lx\n",
-        strftime("%H:%M:%S", nsecs), (nsecs % 1000000000) / 1000000,
-        "!MPROT_X", args->start, args->len, args->prot);
+        ts_str($t), ts_ms($t), "!MPROT_X",
+        args->start, args->len, args->prot);
 }
 
 // prctl PR_SET_DUMPABLE=0 (arg0=4, arg1=0) — makes the process
@@ -384,9 +412,9 @@ tracepoint:syscalls:sys_enter_mprotect
 tracepoint:syscalls:sys_enter_prctl
 /@watched[(int64)pid] && args->option == 4 && args->arg2 == 0/
 {
+    $t = nsecs;
     printf("%s.%03d      %-10s PR_SET_DUMPABLE=0\n",
-        strftime("%H:%M:%S", nsecs), (nsecs % 1000000000) / 1000000,
-        "!NODUMP");
+        ts_str($t), ts_ms($t), "!NODUMP");
 }
 
 // seccomp — installing seccomp filters could block tracing or
@@ -394,9 +422,9 @@ tracepoint:syscalls:sys_enter_prctl
 tracepoint:syscalls:sys_enter_seccomp
 /@watched[(int64)pid]/
 {
+    $t = nsecs;
     printf("%s.%03d      %-10s op=%u flags=%u\n",
-        strftime("%H:%M:%S", nsecs), (nsecs % 1000000000) / 1000000,
-        "!SECCOMP", args->op, args->flags);
+        ts_str($t), ts_ms($t), "!SECCOMP", args->op, args->flags);
 }
 
 // personality — changing process execution domain. Can be used to
@@ -404,9 +432,9 @@ tracepoint:syscalls:sys_enter_seccomp
 tracepoint:syscalls:sys_enter_personality
 /@watched[(int64)pid]/
 {
+    $t = nsecs;
     printf("%s.%03d      %-10s persona=0x%lx\n",
-        strftime("%H:%M:%S", nsecs), (nsecs % 1000000000) / 1000000,
-        "!PERSONA", args->personality);
+        ts_str($t), ts_ms($t), "!PERSONA", args->personality);
 }
 
 // userfaultfd — used in kernel race-condition exploits. No legitimate
@@ -414,9 +442,9 @@ tracepoint:syscalls:sys_enter_personality
 tracepoint:syscalls:sys_enter_userfaultfd
 /@watched[(int64)pid]/
 {
+    $t = nsecs;
     printf("%s.%03d      %-10s flags=0x%x\n",
-        strftime("%H:%M:%S", nsecs), (nsecs % 1000000000) / 1000000,
-        "!UFFD", args->flags);
+        ts_str($t), ts_ms($t), "!UFFD", args->flags);
 }
 
 // ========================================================================
@@ -428,17 +456,19 @@ tracepoint:syscalls:sys_enter_userfaultfd
 tracepoint:syscalls:sys_enter_symlinkat
 /@watched[(int64)pid]/
 {
+    $t = nsecs;
     printf("%s.%03d      %-10s %s -> %s\n",
-        strftime("%H:%M:%S", nsecs), (nsecs % 1000000000) / 1000000,
-        "!SYMLINK", str(args->oldname), str(args->newname));
+        ts_str($t), ts_ms($t), "!SYMLINK",
+        str(args->oldname), str(args->newname));
 }
 
 tracepoint:syscalls:sys_enter_linkat
 /@watched[(int64)pid]/
 {
+    $t = nsecs;
     printf("%s.%03d      %-10s %s -> %s\n",
-        strftime("%H:%M:%S", nsecs), (nsecs % 1000000000) / 1000000,
-        "!HARDLINK", str(args->oldname), str(args->newname));
+        ts_str($t), ts_ms($t), "!HARDLINK",
+        str(args->oldname), str(args->newname));
 }
 
 // ========================================================================
@@ -450,9 +480,9 @@ tracepoint:syscalls:sys_enter_linkat
 tracepoint:syscalls:sys_enter_keyctl
 /@watched[(int64)pid]/
 {
+    $t = nsecs;
     printf("%s.%03d      %-10s operation=%d\n",
-        strftime("%H:%M:%S", nsecs), (nsecs % 1000000000) / 1000000,
-        "!KEYCTL", args->option);
+        ts_str($t), ts_ms($t), "!KEYCTL", args->option);
 }
 
 // ========================================================================
@@ -463,9 +493,9 @@ tracepoint:syscalls:sys_enter_keyctl
 tracepoint:syscalls:sys_enter_reboot
 /@watched[(int64)pid]/
 {
+    $t = nsecs;
     printf("%s.%03d      %-10s magic=0x%x cmd=0x%x\n",
-        strftime("%H:%M:%S", nsecs), (nsecs % 1000000000) / 1000000,
-        "!REBOOT", args->magic1, args->cmd);
+        ts_str($t), ts_ms($t), "!REBOOT", args->magic1, args->cmd);
 }
 
 // kill — sending signals to processes outside the watched tree could be
@@ -473,9 +503,9 @@ tracepoint:syscalls:sys_enter_reboot
 tracepoint:syscalls:sys_enter_kill
 /@watched[(int64)pid] && !@watched[(int64)args->pid] && args->pid > 0/
 {
+    $t = nsecs;
     printf("%s.%03d      %-10s target_pid=%d signal=%d\n",
-        strftime("%H:%M:%S", nsecs), (nsecs % 1000000000) / 1000000,
-        "!KILL_EXT", args->pid, args->sig);
+        ts_str($t), ts_ms($t), "!KILL_EXT", args->pid, args->sig);
 }
 
 // ========================================================================
@@ -488,9 +518,10 @@ tracepoint:syscalls:sys_enter_kill
 tracepoint:syscalls:sys_enter_fchmodat
 /@watched[(int64)pid] && (args->mode & 06000)/
 {
+    $t = nsecs;
     printf("%s.%03d      %-10s %s (mode %o — setuid/setgid!)\n",
-        strftime("%H:%M:%S", nsecs), (nsecs % 1000000000) / 1000000,
-        "!SUID_CHM", str(args->filename), args->mode);
+        ts_str($t), ts_ms($t), "!SUID_CHM",
+        str(args->filename), args->mode);
 }
 
 // --- Process tracking ---


### PR DESCRIPTION
- Add ts_str(t)/ts_ms(t) timestamp macros across all four scripts, replacing repeated strftime/nsecs boilerplate
- Add flush_agg macro in trace-netcalls.bt to deduplicate the TCP aggregation flush logic (~10 call sites)
- Add ntohs, log_sock_event_v6, log_udp4, log_udp6, and print_agg macros in trace-netcalls.bt for network event formatting
- Split the credential/secret strcontains check in trace-suspicious.bt into two probes to stay within BPF verifier limits