### PR TITLE
Update tracing script for bpftrace 0.25

### DIFF
--- a/coding/process-supervisor/README.md
+++ b/coding/process-supervisor/README.md
@@ -2,7 +2,7 @@
 
 Tools to monitor and sandbox processes on Linux and macOS. While primarily developed to supervise AI coding agents, all tools work with any process.
 
-- **Monitoring** — [bpftrace](https://github.com/bpftrace/bpftrace) scripts that trace what a process and all its descendants are doing (exec, file, network, suspicious ops) using kernel tracepoints, kprobes, and uprobes. Requires Linux with BTF support (`CONFIG_DEBUG_INFO_BTF=y`), bpftrace >= 0.21.
+- **Monitoring** — [bpftrace](https://github.com/bpftrace/bpftrace) scripts that trace what a process and all its descendants are doing (exec, file, network, suspicious ops) using kernel tracepoints, kprobes, and uprobes. Requires Linux with BTF support (`CONFIG_DEBUG_INFO_BTF=y`), bpftrace >= 0.25 (see [8aacaf8](https://github.com/olbat/misc/tree/8aacaf8099f695bdf4c0b40f80040cf26c0f9bdd) for bpftrace < 0.25).
 - **Sandboxing** — a multi-backend jailing script that sandboxes processes with configurable filesystem, command, and network restrictions. Requires Python 3.11+ (or Python 3.6+ with the `tomli` package). Backend-specific requirements: [bubblewrap](https://github.com/containers/bubblewrap) (`bwrap`) on Linux, `sandbox-exec` on macOS (available by default), or Linux kernel 5.13+ for Landlock (no extra dependencies).
 
 Example configuration files for popular AI coding agents are provided in the `confs/` directory.

--- a/coding/process-supervisor/monitor-process.sh
+++ b/coding/process-supervisor/monitor-process.sh
@@ -237,11 +237,11 @@ else
 fi
 
 # --- Attach bpftrace scripts (elevated) ---
-# Each bpftrace is wrapped with stdbuf -oL to force line-buffered
-# output. This ensures lines are flushed to the log file promptly and
-# that concurrent writers don't interleave partial lines (each line
-# write is a single write() call, well under the PIPE_BUF atomic
-# guarantee of 4096 bytes on Linux).
+# bpftrace -B line forces line-buffered output (including to files,
+# since v0.25). This ensures lines are flushed to the log file
+# promptly and that concurrent writers don't interleave partial lines
+# (each line write is a single write() call, well under the PIPE_BUF
+# atomic guarantee of 4096 bytes on Linux).
 #
 # When outputting to stdout, we open fd 3 as a copy of stdout so that
 # backgrounded processes can write to it reliably.
@@ -254,30 +254,30 @@ fi
 
 if [[ "$TRACE_EXECS" -eq 1 ]]; then
     echo "[monitor-process] Attaching exec tracer..."
-    sudo stdbuf -oL bpftrace "$SCRIPT_DIR/trace-execs.bt" "$TARGET_PID" >> "$OUT_REDIR" 2>&1 &
+    sudo bpftrace -B line "$SCRIPT_DIR/trace-execs.bt" "$TARGET_PID" >> "$OUT_REDIR" 2>&1 &
     BPFTRACE_PIDS+=($!)
 fi
 
 if [[ "$TRACE_FILES" -eq 1 ]]; then
     echo "[monitor-process] Attaching file tracer..."
     if [[ -n "$FILE_FILTER" ]]; then
-        sudo stdbuf -oL bpftrace "$SCRIPT_DIR/trace-files.bt" "$TARGET_PID" 2>&1 \
-            | stdbuf -oL grep --line-buffered -vE "$FILE_FILTER" >> "$OUT_REDIR" &
+        sudo bpftrace -B line "$SCRIPT_DIR/trace-files.bt" "$TARGET_PID" 2>&1 \
+            | grep --line-buffered -vE "$FILE_FILTER" >> "$OUT_REDIR" &
     else
-        sudo stdbuf -oL bpftrace "$SCRIPT_DIR/trace-files.bt" "$TARGET_PID" >> "$OUT_REDIR" 2>&1 &
+        sudo bpftrace -B line "$SCRIPT_DIR/trace-files.bt" "$TARGET_PID" >> "$OUT_REDIR" 2>&1 &
     fi
     BPFTRACE_PIDS+=($!)
 fi
 
 if [[ "$TRACE_NETCALLS" -eq 1 ]]; then
     echo "[monitor-process] Attaching network tracer..."
-    sudo stdbuf -oL bpftrace "$SCRIPT_DIR/trace-netcalls.bt" "$TARGET_PID" >> "$OUT_REDIR" 2>&1 &
+    sudo bpftrace -B line "$SCRIPT_DIR/trace-netcalls.bt" "$TARGET_PID" >> "$OUT_REDIR" 2>&1 &
     BPFTRACE_PIDS+=($!)
 fi
 
 if [[ "$TRACE_SUSPICIOUS" -eq 1 ]]; then
     echo "[monitor-process] Attaching suspicious ops tracer..."
-    sudo stdbuf -oL bpftrace "$SCRIPT_DIR/trace-suspicious.bt" "$TARGET_PID" >> "$OUT_REDIR" 2>&1 &
+    sudo bpftrace -B line "$SCRIPT_DIR/trace-suspicious.bt" "$TARGET_PID" >> "$OUT_REDIR" 2>&1 &
     BPFTRACE_PIDS+=($!)
 fi
 

--- a/coding/process-supervisor/monitor-process.sh
+++ b/coding/process-supervisor/monitor-process.sh
@@ -2,8 +2,10 @@
 #
 # monitor-process.sh
 #
-# Attaches bpftrace scripts (execs, files, netcalls, suspicious) with
-# elevated privileges to monitor a process and all its descendants.
+# Builds a combined bpftrace script from trace-common.bt and the enabled
+# tracer modules (execs, files, netcalls, suspicious), then runs a single
+# bpftrace process with elevated privileges to monitor a process and all
+# its descendants.
 #
 # Two modes:
 #   Run mode:    Launch a command and trace it (default)
@@ -29,7 +31,7 @@
 #   -p, --pid PID              Attach to an existing process instead of
 #                              launching a new one
 #   -o, --output FILE          Write traces to FILE (default: temp file)
-#   -f, --filter REGEX         Exclude file-tracer lines matching REGEX
+#   -f, --filter REGEX         Exclude output lines matching REGEX
 #                              (grep -vE; see monitor-claude.conf for an example)
 #       --no-filter            Disable the exclusion filter
 #   -E, --disable-execs        Disable subprocess/exec tracing
@@ -80,7 +82,7 @@ Options:
   -p, --pid PID              Attach to an existing process instead of
                              launching a new one
   -o, --output FILE          Write traces to FILE (default: temp file)
-  -f, --filter REGEX         Exclude file-tracer lines matching REGEX
+  -f, --filter REGEX         Exclude output lines matching REGEX
                              (grep -vE; see monitor-claude.conf for an example)
       --no-filter            Disable the exclusion filter
   -E, --disable-execs        Disable subprocess/exec tracing
@@ -126,7 +128,7 @@ eval set -- "$OPTS"
 
 while true; do
     case "$1" in
-        -c|--config)             source "$2";          shift 2 ;;
+        -c|--config)             source "$2";         shift 2 ;;
         -p|--pid)                ATTACH_PID="$2";     shift 2 ;;
         -o|--output)             LOG_FILE="$2";       shift 2 ;;
         -f|--filter)             FILE_FILTER="$2";    shift 2 ;;
@@ -151,6 +153,73 @@ if [[ -z "$ATTACH_PID" && $# -eq 0 ]]; then
     usage
 fi
 
+# --- Build combined bpftrace script ---
+# Concatenate trace-common.bt (shared preamble) with enabled tracer
+# modules, then append a shared postamble for process-exit cleanup.
+# Tracer-specific exit handlers (e.g. netcalls flush_agg) are placed
+# before the shared handler so they fire first.
+TRACERS_ENABLED=0
+COMBINED_SCRIPT=$(mktemp "/tmp/monitor-combined.XXXXXX.bt")
+
+cat "$SCRIPT_DIR/trace-common.bt" >> "$COMBINED_SCRIPT"
+
+if [[ "$TRACE_EXECS" -eq 1 ]]; then
+    echo "[monitor-process] Including exec tracer"
+    cat "$SCRIPT_DIR/trace-execs.bt" >> "$COMBINED_SCRIPT"
+    ((TRACERS_ENABLED++)) || true
+fi
+
+if [[ "$TRACE_FILES" -eq 1 ]]; then
+    echo "[monitor-process] Including file tracer"
+    cat "$SCRIPT_DIR/trace-files.bt" >> "$COMBINED_SCRIPT"
+    ((TRACERS_ENABLED++)) || true
+fi
+
+if [[ "$TRACE_NETCALLS" -eq 1 ]]; then
+    echo "[monitor-process] Including network tracer"
+    cat "$SCRIPT_DIR/trace-netcalls.bt" >> "$COMBINED_SCRIPT"
+    ((TRACERS_ENABLED++)) || true
+fi
+
+if [[ "$TRACE_SUSPICIOUS" -eq 1 ]]; then
+    echo "[monitor-process] Including suspicious ops tracer"
+    cat "$SCRIPT_DIR/trace-suspicious.bt" >> "$COMBINED_SCRIPT"
+    ((TRACERS_ENABLED++)) || true
+fi
+
+if [[ "$TRACERS_ENABLED" -eq 0 ]]; then
+    echo "[monitor-process] All tracers disabled, nothing to do." >&2
+    rm -f "$COMBINED_SCRIPT"
+    exit 1
+fi
+
+# Append shared postamble: process-exit cleanup and root-exit handler.
+# This must come AFTER all tracer modules so that tracer-specific exit
+# handlers (e.g. netcalls flush_agg) fire before @watched is cleaned up.
+cat >> "$COMBINED_SCRIPT" << 'POSTAMBLE'
+
+// --- Shared process tracking (appended by monitor-process.sh) ---
+
+tracepoint:sched:sched_process_exit
+/(@watched[(int64)pid]) && tid == pid/
+{
+    $_ = delete(@watched[(int64)pid]);
+}
+
+tracepoint:sched:sched_process_exit
+/(tid == (uint64)@root_pid)/
+{
+    printf("\nRoot process %d exited. Stopping monitor.\n", @root_pid);
+    exit();
+}
+
+END
+{
+    clear(@watched);
+    $_ = delete(@root_pid);
+}
+POSTAMBLE
+
 # --- Output setup ---
 # In attach mode, default to stdout (no interleaving risk since we
 # didn't launch the process). In run mode, default to a temp file.
@@ -173,7 +242,7 @@ echo "[monitor-process] bpftrace requires root — requesting sudo credentials..
 sudo -v
 
 # --- Child PID tracking ---
-BPFTRACE_PIDS=()
+BPFTRACE_PID=""
 TARGET_PID=""
 TARGET_OWNED=0
 CLEANING_UP=0
@@ -187,11 +256,10 @@ cleanup() {
     echo ""
     echo "[monitor-process] Cleaning up..."
 
-    # Tracked PIDs may be root-owned (bpftrace/sudo) or user-owned
-    # (grep, when filtering is active). Try both; one will succeed.
-    for child_pid in "${BPFTRACE_PIDS[@]}"; do
-        kill "$child_pid" 2>/dev/null || sudo kill "$child_pid" 2>/dev/null || true
-    done
+    # Kill the bpftrace process (root-owned via sudo) and any filter pipe
+    if [[ -n "$BPFTRACE_PID" ]]; then
+        kill "$BPFTRACE_PID" 2>/dev/null || sudo kill "$BPFTRACE_PID" 2>/dev/null || true
+    fi
 
     # We never kill the target — we only trace, we don't own its lifecycle.
     if [[ -n "$TARGET_PID" ]] && kill -0 "$TARGET_PID" 2>/dev/null; then
@@ -199,6 +267,7 @@ cleanup() {
     fi
 
     wait 2>/dev/null || true
+    rm -f "$COMBINED_SCRIPT"
     if [[ "$LOG_TO_STDOUT" -eq 0 ]]; then
         echo "[monitor-process] Traces saved to: $LOG_FILE"
     fi
@@ -236,15 +305,9 @@ else
     fi
 fi
 
-# --- Attach bpftrace scripts (elevated) ---
+# --- Run single combined bpftrace (elevated) ---
 # bpftrace -B line forces line-buffered output (including to files,
-# since v0.25). This ensures lines are flushed to the log file
-# promptly and that concurrent writers don't interleave partial lines
-# (each line write is a single write() call, well under the PIPE_BUF
-# atomic guarantee of 4096 bytes on Linux).
-#
-# When outputting to stdout, we open fd 3 as a copy of stdout so that
-# backgrounded processes can write to it reliably.
+# since v0.25). When a FILE_FILTER is active, pipe through grep.
 if [[ "$LOG_TO_STDOUT" -eq 1 ]]; then
     exec 3>&1
     OUT_REDIR="/dev/fd/3"
@@ -252,41 +315,15 @@ else
     OUT_REDIR="$LOG_FILE"
 fi
 
-if [[ "$TRACE_EXECS" -eq 1 ]]; then
-    echo "[monitor-process] Attaching exec tracer..."
-    sudo bpftrace -B line "$SCRIPT_DIR/trace-execs.bt" "$TARGET_PID" >> "$OUT_REDIR" 2>&1 &
-    BPFTRACE_PIDS+=($!)
+echo "[monitor-process] Starting bpftrace with $TRACERS_ENABLED tracer(s)..."
+if [[ -n "$FILE_FILTER" ]]; then
+    sudo bpftrace -B line "$COMBINED_SCRIPT" "$TARGET_PID" 2>&1 \
+        | grep --line-buffered -vE "$FILE_FILTER" >> "$OUT_REDIR" &
+else
+    sudo bpftrace -B line "$COMBINED_SCRIPT" "$TARGET_PID" >> "$OUT_REDIR" 2>&1 &
 fi
+BPFTRACE_PID=$!
 
-if [[ "$TRACE_FILES" -eq 1 ]]; then
-    echo "[monitor-process] Attaching file tracer..."
-    if [[ -n "$FILE_FILTER" ]]; then
-        sudo bpftrace -B line "$SCRIPT_DIR/trace-files.bt" "$TARGET_PID" 2>&1 \
-            | grep --line-buffered -vE "$FILE_FILTER" >> "$OUT_REDIR" &
-    else
-        sudo bpftrace -B line "$SCRIPT_DIR/trace-files.bt" "$TARGET_PID" >> "$OUT_REDIR" 2>&1 &
-    fi
-    BPFTRACE_PIDS+=($!)
-fi
-
-if [[ "$TRACE_NETCALLS" -eq 1 ]]; then
-    echo "[monitor-process] Attaching network tracer..."
-    sudo bpftrace -B line "$SCRIPT_DIR/trace-netcalls.bt" "$TARGET_PID" >> "$OUT_REDIR" 2>&1 &
-    BPFTRACE_PIDS+=($!)
-fi
-
-if [[ "$TRACE_SUSPICIOUS" -eq 1 ]]; then
-    echo "[monitor-process] Attaching suspicious ops tracer..."
-    sudo bpftrace -B line "$SCRIPT_DIR/trace-suspicious.bt" "$TARGET_PID" >> "$OUT_REDIR" 2>&1 &
-    BPFTRACE_PIDS+=($!)
-fi
-
-if [[ ${#BPFTRACE_PIDS[@]} -eq 0 ]]; then
-    echo "[monitor-process] All tracers disabled, nothing to do." >&2
-    exit 1
-fi
-
-echo "[monitor-process] ${#BPFTRACE_PIDS[@]} tracer(s) attached."
 if [[ "$LOG_TO_STDOUT" -eq 0 ]]; then
     echo "[monitor-process] Traces: $LOG_FILE"
     echo "[monitor-process] Follow live with: tail -f $LOG_FILE"

--- a/coding/process-supervisor/trace-all.sh
+++ b/coding/process-supervisor/trace-all.sh
@@ -2,8 +2,8 @@
 #
 # trace-all.sh
 #
-# Runs all trace-*.bt bpftrace scripts in the same directory in parallel
-# against the same target PID. Ctrl-C stops all.
+# Concatenates trace-common.bt with all trace-*.bt modules and runs
+# them as a single bpftrace process against the target PID.
 #
 # Usage: sudo ./trace-all.sh <PID>
 
@@ -18,15 +18,39 @@ fi
 
 PID="$1"
 
-# Kill all child bpftrace processes on exit
-cleanup() {
-    kill 0 2>/dev/null
-    wait 2>/dev/null
-}
-trap cleanup EXIT INT TERM QUIT HUP
+# Build combined script: common preamble + all tracer modules + postamble
+COMBINED=$(mktemp "/tmp/trace-all.XXXXXX.bt")
+trap 'rm -f "$COMBINED"' EXIT INT TERM QUIT HUP
 
-for script in "$SCRIPT_DIR"/trace-*.bt; do
-    bpftrace "$script" "$PID" &
+cat "$SCRIPT_DIR/trace-common.bt" > "$COMBINED"
+
+for module in "$SCRIPT_DIR"/trace-{execs,files,netcalls,suspicious}.bt; do
+    cat "$module" >> "$COMBINED"
 done
 
-wait
+# Shared postamble: process-exit cleanup and root-exit handler
+cat >> "$COMBINED" << 'POSTAMBLE'
+
+// --- Shared process tracking (appended by trace-all.sh) ---
+
+tracepoint:sched:sched_process_exit
+/(@watched[(int64)pid]) && tid == pid/
+{
+    delete(@watched[(int64)pid]);
+}
+
+tracepoint:sched:sched_process_exit
+/(tid == (uint64)@root_pid)/
+{
+    printf("\nRoot process %d exited. Stopping monitor.\n", @root_pid);
+    exit();
+}
+
+END
+{
+    clear(@watched);
+    delete(@root_pid);
+}
+POSTAMBLE
+
+bpftrace -B line "$COMBINED" "$PID"

--- a/coding/process-supervisor/trace-common.bt
+++ b/coding/process-supervisor/trace-common.bt
@@ -1,0 +1,41 @@
+/*
+ * trace-common.bt
+ *
+ * Shared preamble for process monitoring scripts. Provides timestamp
+ * macros, process-tree tracking, and lifecycle management.
+ *
+ * Not intended to be run standalone. Combined with tracer modules by
+ * monitor-process.sh (or manually via cat):
+ *
+ *   cat trace-common.bt trace-files.bt | sudo bpftrace - <PID>
+ *
+ * Requires: kernel BTF support (CONFIG_DEBUG_INFO_BTF=y), bpftrace >= 0.25
+ */
+
+// Timestamp: HH:MM:SS string and milliseconds within the current second
+macro ts_str(t) { strftime("%H:%M:%S", t) }
+macro ts_ms(t)  { (t % 1000000000) / 1000000 }
+
+// Network to host byte order for 16-bit values
+macro ntohs(raw) { ((raw >> 8) | ((raw & 0xff) << 8)) }
+
+BEGIN
+{
+    if ($1 == 0) {
+        printf("Usage: sudo bpftrace <script> <PID>\n");
+        exit();
+    }
+    printf("Monitoring PID %d (and their children)...\n", $1);
+    printf("%-20s %-10s %s\n", "TIME", "EVENT", "DETAILS");
+    printf("%-20s %-10s %s\n", "----", "-----", "-------");
+
+    @root_pid = $1;
+    @watched[($1)] = 1;
+}
+
+tracepoint:sched:sched_process_fork
+{
+    if (@watched[(int64)pid]) {
+        @watched[args.child_pid] = 1;
+    }
+}

--- a/coding/process-supervisor/trace-execs.bt
+++ b/coding/process-supervisor/trace-execs.bt
@@ -8,8 +8,6 @@
  * Usage: sudo bpftrace monitor_subprocesses.bt <PID>
  */
 
-config = { unstable_macro=enable; }
-
 // Timestamp: HH:MM:SS string and milliseconds within the current second
 macro ts_str(t) { strftime("%H:%M:%S", t) }
 macro ts_ms(t)  { (t % 1000000000) / 1000000 }
@@ -33,8 +31,8 @@ BEGIN
 // Track new processes: if the parent is watched, watch the child too
 tracepoint:sched:sched_process_fork
 {
-    if (@watched[args->parent_pid]) {
-        @watched[args->child_pid] = 1;
+    if (@watched[args.parent_pid]) {
+        @watched[args.child_pid] = 1;
     }
 }
 
@@ -43,8 +41,8 @@ tracepoint:syscalls:sys_enter_execve
 /(@watched[(int64)pid])/
 {
     $t = nsecs;
-    printf("%s.%03d      %-10s ", ts_str($t), ts_ms($t), "EXEC");
-    join(args->argv);
+    printf("%s.%03d      %-10s %s[%d] ", ts_str($t), ts_ms($t), "EXEC", comm, pid);
+    join(args.argv);
 }
 
 // Stop watching processes that have exited (only when main thread exits)

--- a/coding/process-supervisor/trace-execs.bt
+++ b/coding/process-supervisor/trace-execs.bt
@@ -1,40 +1,13 @@
-#!/usr/bin/env bpftrace
 /*
- * trace-execs.bt
+ * trace-execs.bt — Exec tracer module
  *
- * Monitor sub-processes spawned by a specific process (and its descendants).
- * For each exec() call, print the timestamp, PID, and full command with args.
+ * Monitor sub-processes spawned by the watched process tree.
+ * For each exec() call, print the timestamp, caller comm/PID, and full
+ * command with args.
  *
- * Usage: sudo bpftrace monitor_subprocesses.bt <PID>
+ * Requires trace-common.bt preamble:
+ *   cat trace-common.bt trace-execs.bt | sudo bpftrace - <PID>
  */
-
-// Timestamp: HH:MM:SS string and milliseconds within the current second
-macro ts_str(t) { strftime("%H:%M:%S", t) }
-macro ts_ms(t)  { (t % 1000000000) / 1000000 }
-
-BEGIN
-{
-    if ($1 == 0) {
-        printf("Usage: sudo bpftrace monitor_subprocesses.bt <PID>\n");
-        exit();
-    }
-    printf("Monitoring subprocesses of PID %d (and their children)...\n", $1);
-    printf("%-20s %-10s %s\n", "TIME", "EVENT", "DETAILS");
-    printf("%-20s %-10s %s\n", "----", "-----", "-------");
-
-    // Track the root PID to monitor
-    @root_pid = $1;
-    // Seed the watched set with the root PID
-    @watched[($1)] = 1;
-}
-
-// Track new processes: if the parent is watched, watch the child too
-tracepoint:sched:sched_process_fork
-{
-    if (@watched[args.parent_pid]) {
-        @watched[args.child_pid] = 1;
-    }
-}
 
 // On exec, if the process is watched, log the command
 tracepoint:syscalls:sys_enter_execve
@@ -43,25 +16,4 @@ tracepoint:syscalls:sys_enter_execve
     $t = nsecs;
     printf("%s.%03d      %-10s %s[%d] ", ts_str($t), ts_ms($t), "EXEC", comm, pid);
     join(args.argv);
-}
-
-// Stop watching processes that have exited (only when main thread exits)
-tracepoint:sched:sched_process_exit
-/(@watched[(int64)pid]) && tid == pid/
-{
-    delete(@watched[(int64)pid]);
-}
-
-// If the root process exits, clean up and exit
-tracepoint:sched:sched_process_exit
-/(tid == (uint64)@root_pid)/
-{
-    printf("\nRoot process %d exited. Stopping monitor.\n", @root_pid);
-    exit();
-}
-
-END
-{
-    clear(@watched);
-    delete(@root_pid);
 }

--- a/coding/process-supervisor/trace-files.bt
+++ b/coding/process-supervisor/trace-files.bt
@@ -5,11 +5,9 @@
  * Monitor file operations (open, read, write, mkdir, delete, rename) made by a
  * specific process and its descendants.
  *
- * Requires: kernel BTF support (CONFIG_DEBUG_INFO_BTF=y), bpftrace >= 0.21
+ * Requires: kernel BTF support (CONFIG_DEBUG_INFO_BTF=y), bpftrace >= 0.25
  * Usage: sudo bpftrace trace-files.bt <PID>
  */
-
-config = { unstable_macro=enable; }
 
 // Timestamp: HH:MM:SS string and milliseconds within the current second
 macro ts_str(t) { strftime("%H:%M:%S", t) }
@@ -32,7 +30,7 @@ BEGIN
 tracepoint:sched:sched_process_fork
 {
     if (@watched[(int64)pid]) {
-        @watched[args->child_pid] = 1;
+        @watched[args.child_pid] = 1;
     }
 }
 
@@ -41,16 +39,15 @@ tracepoint:sched:sched_process_fork
 tracepoint:syscalls:sys_enter_openat
 /@watched[(int64)pid]/
 {
-    @open_path[tid] = str(args->filename);
-    @open_flags[tid] = args->flags;
+    @open_info[tid] = (path=str(args.filename), flags=args.flags);
 }
 
 tracepoint:syscalls:sys_exit_openat
-/@open_path[tid] != ""/
+/@open_info[tid].path != ""/
 {
     $t = nsecs;
-    $flags = @open_flags[tid];
-    $path = @open_path[tid];
+    $flags = @open_info[tid].flags;
+    $path = @open_info[tid].path;
 
     if ($flags & 0x40) {
         // O_CREAT
@@ -64,40 +61,39 @@ tracepoint:syscalls:sys_exit_openat
     }
 
     // Map fd to path for subsequent read/write tracking
-    if (args->ret >= 0) {
-        @fd_to_path[pid, args->ret] = $path;
+    if (args.ret >= 0) {
+        @fd_to_path[pid, args.ret] = $path;
     }
 
-    delete(@open_path[tid]);
-    delete(@open_flags[tid]);
+    delete(@open_info[tid]);
 }
 
 // --- File read/write ---
 
 tracepoint:syscalls:sys_enter_read
-/@watched[(int64)pid] && @fd_to_path[pid, (int64)args->fd] != ""/
+/@watched[(int64)pid] && @fd_to_path[pid, (int64)args.fd] != ""/
 {
     $t = nsecs;
     printf("%s.%03d      %-10s %s (%d bytes)\n",
         ts_str($t), ts_ms($t), "READ",
-        @fd_to_path[pid, (int64)args->fd], args->count);
+        @fd_to_path[pid, (int64)args.fd], args.count);
 }
 
 tracepoint:syscalls:sys_enter_write
-/@watched[(int64)pid] && @fd_to_path[pid, (int64)args->fd] != ""/
+/@watched[(int64)pid] && @fd_to_path[pid, (int64)args.fd] != ""/
 {
     $t = nsecs;
     printf("%s.%03d      %-10s %s (%d bytes)\n",
         ts_str($t), ts_ms($t), "WRITE",
-        @fd_to_path[pid, (int64)args->fd], args->count);
+        @fd_to_path[pid, (int64)args.fd], args.count);
 }
 
 // --- File close (cleanup fd mapping) ---
 
 tracepoint:syscalls:sys_enter_close
-/@watched[(int64)pid] && @fd_to_path[pid, (int64)args->fd] != ""/
+/@watched[(int64)pid] && @fd_to_path[pid, (int64)args.fd] != ""/
 {
-    delete(@fd_to_path[pid, (int64)args->fd]);
+    delete(@fd_to_path[pid, (int64)args.fd]);
 }
 
 // --- Directory create ---
@@ -108,7 +104,7 @@ tracepoint:syscalls:sys_enter_mkdirat
     $t = nsecs;
     printf("%s.%03d      %-10s %s (mode %o)\n",
         ts_str($t), ts_ms($t), "MKDIR",
-        str(args->pathname), args->mode);
+        str(args.pathname), args.mode);
 }
 
 // --- File delete ---
@@ -118,7 +114,7 @@ tracepoint:syscalls:sys_enter_unlinkat
 {
     $t = nsecs;
     printf("%s.%03d      %-10s %s\n",
-        ts_str($t), ts_ms($t), "DELETE", str(args->pathname));
+        ts_str($t), ts_ms($t), "DELETE", str(args.pathname));
 }
 
 // --- File rename ---
@@ -129,7 +125,7 @@ tracepoint:syscalls:sys_enter_renameat2
     $t = nsecs;
     printf("%s.%03d      %-10s %s -> %s\n",
         ts_str($t), ts_ms($t), "RENAME",
-        str(args->oldname), str(args->newname));
+        str(args.oldname), str(args.newname));
 }
 
 // --- File chmod ---
@@ -140,7 +136,7 @@ tracepoint:syscalls:sys_enter_fchmodat
     $t = nsecs;
     printf("%s.%03d      %-10s %s (mode %o)\n",
         ts_str($t), ts_ms($t), "CHMOD",
-        str(args->filename), args->mode);
+        str(args.filename), args.mode);
 }
 
 // --- File chown ---
@@ -151,7 +147,7 @@ tracepoint:syscalls:sys_enter_fchownat
     $t = nsecs;
     printf("%s.%03d      %-10s %s (uid %d, gid %d)\n",
         ts_str($t), ts_ms($t), "CHOWN",
-        str(args->filename), args->user, args->group);
+        str(args.filename), args.user, args.group);
 }
 
 // --- Process tracking ---
@@ -175,7 +171,6 @@ END
 {
     clear(@watched);
     clear(@fd_to_path);
-    clear(@open_path);
-    clear(@open_flags);
+    clear(@open_info);
     delete(@root_pid);
 }

--- a/coding/process-supervisor/trace-files.bt
+++ b/coding/process-supervisor/trace-files.bt
@@ -1,53 +1,27 @@
-#!/usr/bin/env bpftrace
 /*
- * trace-files.bt
+ * trace-files.bt — File operation tracer module
  *
- * Monitor file operations (open, read, write, mkdir, delete, rename) made by a
- * specific process and its descendants.
+ * Monitor file operations (open, read, write, mkdir, delete, rename,
+ * chmod, chown) made by the watched process tree.
  *
- * Requires: kernel BTF support (CONFIG_DEBUG_INFO_BTF=y), bpftrace >= 0.25
- * Usage: sudo bpftrace trace-files.bt <PID>
+ * Requires trace-common.bt preamble:
+ *   cat trace-common.bt trace-files.bt | sudo bpftrace - <PID>
  */
-
-// Timestamp: HH:MM:SS string and milliseconds within the current second
-macro ts_str(t) { strftime("%H:%M:%S", t) }
-macro ts_ms(t)  { (t % 1000000000) / 1000000 }
-
-BEGIN
-{
-    if ($1 == 0) {
-        printf("Usage: sudo bpftrace trace-files.bt <PID>\n");
-        exit();
-    }
-    printf("Monitoring file operations of PID %d (and their children)...\n", $1);
-    printf("%-20s %-10s %s\n", "TIME", "EVENT", "DETAILS");
-    printf("%-20s %-10s %s\n", "----", "-----", "-------");
-
-    @root_pid = $1;
-    @watched[($1)] = 1;
-}
-
-tracepoint:sched:sched_process_fork
-{
-    if (@watched[(int64)pid]) {
-        @watched[args.child_pid] = 1;
-    }
-}
 
 // --- File open ---
 // Save filename and flags at entry, complete at exit when we have the fd.
 tracepoint:syscalls:sys_enter_openat
 /@watched[(int64)pid]/
 {
-    @open_info[tid] = (path=str(args.filename), flags=args.flags);
+    @fil_open[tid] = (path=str(args.filename), flags=args.flags);
 }
 
 tracepoint:syscalls:sys_exit_openat
-/@open_info[tid].path != ""/
+/@fil_open[tid].path != ""/
 {
     $t = nsecs;
-    $flags = @open_info[tid].flags;
-    $path = @open_info[tid].path;
+    $flags = @fil_open[tid].flags;
+    $path = @fil_open[tid].path;
 
     if ($flags & 0x40) {
         // O_CREAT
@@ -65,7 +39,7 @@ tracepoint:syscalls:sys_exit_openat
         @fd_to_path[pid, args.ret] = $path;
     }
 
-    delete(@open_info[tid]);
+    $_ = delete(@fil_open[tid]);
 }
 
 // --- File read/write ---
@@ -93,7 +67,7 @@ tracepoint:syscalls:sys_enter_write
 tracepoint:syscalls:sys_enter_close
 /@watched[(int64)pid] && @fd_to_path[pid, (int64)args.fd] != ""/
 {
-    delete(@fd_to_path[pid, (int64)args.fd]);
+    $_ = delete(@fd_to_path[pid, (int64)args.fd]);
 }
 
 // --- Directory create ---
@@ -150,27 +124,8 @@ tracepoint:syscalls:sys_enter_fchownat
         str(args.filename), args.user, args.group);
 }
 
-// --- Process tracking ---
-
-// Stop watching processes that have exited (only when main thread exits)
-tracepoint:sched:sched_process_exit
-/(@watched[(int64)pid]) && tid == pid/
-{
-    delete(@watched[(int64)pid]);
-}
-
-// Exit when the root process's main thread exits
-tracepoint:sched:sched_process_exit
-/(tid == (uint64)@root_pid)/
-{
-    printf("\nRoot process %d exited. Stopping monitor.\n", @root_pid);
-    exit();
-}
-
 END
 {
-    clear(@watched);
     clear(@fd_to_path);
-    clear(@open_info);
-    delete(@root_pid);
+    clear(@fil_open);
 }

--- a/coding/process-supervisor/trace-netcalls.bt
+++ b/coding/process-supervisor/trace-netcalls.bt
@@ -12,11 +12,9 @@
  * user-space pointer reads that silently fail on kernel 5.5+
  * (bpf_probe_read vs bpf_probe_read_user).
  *
- * Requires: kernel BTF support (CONFIG_DEBUG_INFO_BTF=y), bpftrace >= 0.21
+ * Requires: kernel BTF support (CONFIG_DEBUG_INFO_BTF=y), bpftrace >= 0.25
  * Usage: sudo bpftrace trace-netcalls.bt <PID>
  */
-
-config = { unstable_macro=enable; }
 
 // --- Macros ---
 
@@ -29,10 +27,10 @@ macro ntohs(raw) { ((raw >> 8) | ((raw & 0xff) << 8)) }
 
 // Print a TCP event using sock struct fields (IPv6 only, IPv4 uses aggregation).
 macro log_sock_event_v6($sk, event, size, $t) {
-    $dport_v6 = ntohs($sk->__sk_common.skc_dport);
+    $dport_v6 = ntohs($sk.__sk_common.skc_dport);
     printf("%s.%03d      %-10s [%s]:%d (%d bytes)\n",
         ts_str($t), ts_ms($t), event,
-        ntop(10, $sk->__sk_common.skc_v6_daddr.in6_u.u6_addr8), $dport_v6, size);
+        ntop(10, $sk.__sk_common.skc_v6_daddr.in6_u.u6_addr8), $dport_v6, size);
 }
 
 // Print an aggregated IPv4 TCP event — all values passed as args.
@@ -76,8 +74,8 @@ macro flush_agg(@ac, @at, @atm, @ai, @adp, @hbi, @ab) {
 // Resolves destination from msg_name (unconnected) or sock (connected).
 // msg_name is kernel-space at kprobe:udp_sendmsg (copied by move_addr_to_kernel).
 macro log_udp4($sk, $msg, size, $t) {
-    if ($msg->msg_name != 0) {
-        $name_u4 = (uint64)$msg->msg_name;
+    if ($msg.msg_name != 0) {
+        $name_u4 = (uint64)$msg.msg_name;
         $port_u4 = (*(uint8 *)($name_u4 + 2) << 8) | *(uint8 *)($name_u4 + 3);
         if ($port_u4 == 53) {
             printf("%s.%03d      %-10s %s:53 (%d bytes)\n",
@@ -89,23 +87,23 @@ macro log_udp4($sk, $msg, size, $t) {
                 ntop(2, *(uint32 *)($name_u4 + 4)), $port_u4, size);
         }
     } else {
-        $port_u4c = ntohs($sk->__sk_common.skc_dport);
+        $port_u4c = ntohs($sk.__sk_common.skc_dport);
         if ($port_u4c == 53) {
             printf("%s.%03d      %-10s %s:53 (%d bytes)\n",
                 ts_str($t), ts_ms($t), "DNS",
-                ntop(2, $sk->__sk_common.skc_daddr), size);
+                ntop(2, $sk.__sk_common.skc_daddr), size);
         } else {
             printf("%s.%03d      %-10s %s:%d (%d bytes)\n",
                 ts_str($t), ts_ms($t), "TX_UDP",
-                ntop(2, $sk->__sk_common.skc_daddr), $port_u4c, size);
+                ntop(2, $sk.__sk_common.skc_daddr), $port_u4c, size);
         }
     }
 }
 
 // Print an IPv6 UDP event (DNS or TX_UDP).
 macro log_udp6($sk, $msg, size, $t) {
-    if ($msg->msg_name != 0) {
-        $name_u6 = (uint64)$msg->msg_name;
+    if ($msg.msg_name != 0) {
+        $name_u6 = (uint64)$msg.msg_name;
         $port_u6 = (*(uint8 *)($name_u6 + 2) << 8) | *(uint8 *)($name_u6 + 3);
         // sockaddr_in6: sin6_addr at offset 8, 16 bytes
         if ($port_u6 == 53) {
@@ -118,15 +116,15 @@ macro log_udp6($sk, $msg, size, $t) {
                 ntop(10, $name_u6 + 8), $port_u6, size);
         }
     } else {
-        $port_u6c = ntohs($sk->__sk_common.skc_dport);
+        $port_u6c = ntohs($sk.__sk_common.skc_dport);
         if ($port_u6c == 53) {
             printf("%s.%03d      %-10s [%s]:53 (%d bytes)\n",
                 ts_str($t), ts_ms($t), "DNS",
-                ntop(10, $sk->__sk_common.skc_v6_daddr.in6_u.u6_addr8), size);
+                ntop(10, $sk.__sk_common.skc_v6_daddr.in6_u.u6_addr8), size);
         } else {
             printf("%s.%03d      %-10s [%s]:%d (%d bytes)\n",
                 ts_str($t), ts_ms($t), "TX_UDP",
-                ntop(10, $sk->__sk_common.skc_v6_daddr.in6_u.u6_addr8), $port_u6c, size);
+                ntop(10, $sk.__sk_common.skc_v6_daddr.in6_u.u6_addr8), $port_u6c, size);
         }
     }
 }
@@ -150,7 +148,7 @@ BEGIN
 tracepoint:sched:sched_process_fork
 {
     if (@watched[(int64)pid]) {
-        @watched[args->child_pid] = 1;
+        @watched[args.child_pid] = 1;
     }
 }
 
@@ -173,57 +171,57 @@ uprobe:/usr/lib/libc.so.6:getaddrinfo
 
 // TCP connect via socket state change (newstate 2 = TCP_SYN_SENT)
 tracepoint:sock:inet_sock_set_state
-/args->newstate == 2 && @watched[(int64)pid]/
+/args.newstate == 2 && @watched[(int64)pid]/
 {
     flush_agg(@agg_count, @agg_type, @agg_time, @agg_ip, @agg_dport, @host_by_ip, @agg_bytes);
 
     $t = nsecs;
-    if (args->family == 2) {
-        $daddr = (uint32)args->daddr[0] | ((uint32)args->daddr[1] << 8)
-            | ((uint32)args->daddr[2] << 16) | ((uint32)args->daddr[3] << 24);
+    if (args.family == 2) {
+        $daddr = (uint32)args.daddr[0] | ((uint32)args.daddr[1] << 8)
+            | ((uint32)args.daddr[2] << 16) | ((uint32)args.daddr[3] << 24);
         if (@resolve_host[pid] != "") {
             @ip_to_host[$daddr] = @resolve_host[pid];
-            @host_by_ip[ntop(2, args->daddr)] = @resolve_host[pid];
+            @host_by_ip[ntop(2, args.daddr)] = @resolve_host[pid];
         }
         if (@ip_to_host[$daddr] != "") {
             printf("%s.%03d      %-10s %s:%d [%s]\n",
                 ts_str($t), ts_ms($t), "CONNECT",
-                ntop(2, args->daddr), args->dport, @ip_to_host[$daddr]);
+                ntop(2, args.daddr), args.dport, @ip_to_host[$daddr]);
         } else {
             printf("%s.%03d      %-10s %s:%d\n",
                 ts_str($t), ts_ms($t), "CONNECT",
-                ntop(2, args->daddr), args->dport);
+                ntop(2, args.daddr), args.dport);
         }
     }
-    else if (args->family == 10) {
+    else if (args.family == 10) {
         printf("%s.%03d      %-10s [%s]:%d\n",
             ts_str($t), ts_ms($t), "CONNECT",
-            ntop(10, args->daddr_v6), args->dport);
+            ntop(10, args.daddr_v6), args.dport);
     }
 }
 
 // TCP disconnect via socket state change (newstate 7 = TCP_CLOSE)
 tracepoint:sock:inet_sock_set_state
-/args->newstate == 7 && @watched[(int64)pid]/
+/args.newstate == 7 && @watched[(int64)pid]/
 {
     flush_agg(@agg_count, @agg_type, @agg_time, @agg_ip, @agg_dport, @host_by_ip, @agg_bytes);
 
     $t = nsecs;
-    if (args->family == 2) {
-        $ip = ntop(2, args->daddr);
+    if (args.family == 2) {
+        $ip = ntop(2, args.daddr);
         if (@host_by_ip[$ip] != "") {
             printf("%s.%03d      %-10s %s:%d [%s]\n",
                 ts_str($t), ts_ms($t), "CLOSE",
-                $ip, args->dport, @host_by_ip[$ip]);
+                $ip, args.dport, @host_by_ip[$ip]);
         } else {
             printf("%s.%03d      %-10s %s:%d\n",
-                ts_str($t), ts_ms($t), "CLOSE", $ip, args->dport);
+                ts_str($t), ts_ms($t), "CLOSE", $ip, args.dport);
         }
     }
-    else if (args->family == 10) {
+    else if (args.family == 10) {
         printf("%s.%03d      %-10s [%s]:%d\n",
             ts_str($t), ts_ms($t), "CLOSE",
-            ntop(10, args->daddr_v6), args->dport);
+            ntop(10, args.daddr_v6), args.dport);
     }
 }
 
@@ -236,12 +234,12 @@ kprobe:tcp_sendmsg
 {
     $t = nsecs;
     $sk = (struct sock *)arg0;
-    $family = $sk->__sk_common.skc_family;
+    $family = $sk.__sk_common.skc_family;
     $size = (uint64)arg2;
 
     if ($family == 2) {
-        $daddr = $sk->__sk_common.skc_daddr;
-        $dport = ntohs($sk->__sk_common.skc_dport);
+        $daddr = $sk.__sk_common.skc_daddr;
+        $dport = ntohs($sk.__sk_common.skc_dport);
 
         if (@agg_type[pid] == 1 && @agg_daddr[pid] == $daddr && @agg_dport[pid] == $dport) {
             // Same connection, same direction: accumulate
@@ -271,11 +269,11 @@ kprobe:tcp_cleanup_rbuf
     $sk = (struct sock *)arg0;
     $sz = (int64)arg1;
     if ($sz > 0) {
-        $family = $sk->__sk_common.skc_family;
+        $family = $sk.__sk_common.skc_family;
 
         if ($family == 2) {
-            $daddr = $sk->__sk_common.skc_daddr;
-            $dport = ntohs($sk->__sk_common.skc_dport);
+            $daddr = $sk.__sk_common.skc_daddr;
+            $dport = ntohs($sk.__sk_common.skc_dport);
 
             if (@agg_type[pid] == 2 && @agg_daddr[pid] == $daddr && @agg_dport[pid] == $dport) {
                 @agg_bytes[pid] += (uint64)$sz;

--- a/coding/process-supervisor/trace-netcalls.bt
+++ b/coding/process-supervisor/trace-netcalls.bt
@@ -1,9 +1,8 @@
-#!/usr/bin/env bpftrace
 /*
- * trace-netcalls.bt
+ * trace-netcalls.bt — Network tracer module
  *
  * Monitor outbound network calls (TCP connect, DNS lookups, data transfer)
- * made by a specific process and its descendants.
+ * made by the watched process tree.
  *
  * Consecutive TCP send/receive events for the same connection are aggregated
  * into a single line showing total bytes and call count.
@@ -12,18 +11,11 @@
  * user-space pointer reads that silently fail on kernel 5.5+
  * (bpf_probe_read vs bpf_probe_read_user).
  *
- * Requires: kernel BTF support (CONFIG_DEBUG_INFO_BTF=y), bpftrace >= 0.25
- * Usage: sudo bpftrace trace-netcalls.bt <PID>
+ * Requires trace-common.bt preamble:
+ *   cat trace-common.bt trace-netcalls.bt | sudo bpftrace - <PID>
  */
 
 // --- Macros ---
-
-// Timestamp: HH:MM:SS string and milliseconds within the current second
-macro ts_str(t) { strftime("%H:%M:%S", t) }
-macro ts_ms(t)  { (t % 1000000000) / 1000000 }
-
-// Network to host byte order for 16-bit values
-macro ntohs(raw) { ((raw >> 8) | ((raw & 0xff) << 8)) }
 
 // Print a TCP event using sock struct fields (IPv6 only, IPv4 uses aggregation).
 macro log_sock_event_v6($sk, event, size, $t) {
@@ -130,27 +122,6 @@ macro log_udp6($sk, $msg, size, $t) {
 }
 
 // --- Probes ---
-
-BEGIN
-{
-    if ($1 == 0) {
-        printf("Usage: sudo bpftrace trace-netcalls.bt <PID>\n");
-        exit();
-    }
-    printf("Monitoring network calls of PID %d (and their children)...\n", $1);
-    printf("%-20s %-10s %s\n", "TIME", "EVENT", "DETAILS");
-    printf("%-20s %-10s %s\n", "----", "-----", "-------");
-
-    @root_pid = $1;
-    @watched[($1)] = 1;
-}
-
-tracepoint:sched:sched_process_fork
-{
-    if (@watched[(int64)pid]) {
-        @watched[args.child_pid] = 1;
-    }
-}
 
 /*
  * Hostname resolution — uprobe on libc's getaddrinfo.
@@ -317,26 +288,15 @@ kprobe:udpv6_sendmsg
     log_udp6($sk, $msg, (uint64)arg2, $t);
 }
 
-// Stop watching processes that have exited (only when main thread exits)
+// Flush pending aggregation when a watched process exits
 tracepoint:sched:sched_process_exit
 /(@watched[(int64)pid]) && tid == pid/
 {
-    // Flush pending aggregation for this process
     flush_agg(@agg_count, @agg_type, @agg_time, @agg_ip, @agg_dport, @host_by_ip, @agg_bytes);
-    delete(@watched[(int64)pid]);
-}
-
-// Exit when the root process's main thread exits
-tracepoint:sched:sched_process_exit
-/(tid == (uint64)@root_pid)/
-{
-    printf("\nRoot process %d exited. Stopping monitor.\n", @root_pid);
-    exit();
 }
 
 END
 {
-    clear(@watched);
     clear(@ip_to_host);
     clear(@host_by_ip);
     clear(@resolve_host);
@@ -347,5 +307,4 @@ END
     clear(@agg_bytes);
     clear(@agg_count);
     clear(@agg_time);
-    delete(@root_pid);
 }

--- a/coding/process-supervisor/trace-suspicious.bt
+++ b/coding/process-supervisor/trace-suspicious.bt
@@ -22,11 +22,9 @@
  *   - Destructive actions (reboot, kill outside watched tree)
  *   - Permission manipulation (setting setuid/setgid bits)
  *
- * Requires: kernel BTF support (CONFIG_DEBUG_INFO_BTF=y), bpftrace >= 0.21
+ * Requires: kernel BTF support (CONFIG_DEBUG_INFO_BTF=y), bpftrace >= 0.25
  * Usage: sudo bpftrace trace-suspicious.bt <PID>
  */
-
-config = { unstable_macro=enable; }
 
 // Timestamp: HH:MM:SS string and milliseconds within the current second
 macro ts_str(t) { strftime("%H:%M:%S", t) }
@@ -49,7 +47,7 @@ BEGIN
 tracepoint:sched:sched_process_fork
 {
     if (@watched[(int64)pid]) {
-        @watched[args->child_pid] = 1;
+        @watched[args.child_pid] = 1;
     }
 }
 
@@ -65,17 +63,17 @@ tracepoint:sched:sched_process_fork
 tracepoint:syscalls:sys_enter_openat
 /@watched[(int64)pid]/
 {
-    @open_path[tid] = str(args->filename, 64);
-    @open_write[tid] = (args->flags & 3) > 0 || (args->flags & 0x40) ? 1 : 0;
+    @open_info[tid] = (path=str(args.filename, 64),
+                       write=(args.flags & 3) > 0 || (args.flags & 0x40) ? 1 : 0);
 }
 
 // --- Credential / secret files (1/2) ---
 // SSH keys, GPG keyrings, cloud credentials, GitHub CLI tokens.
 // The traced process has no business reading these.
 tracepoint:syscalls:sys_exit_openat
-/@open_path[tid] != ""/
+/@open_info[tid].path != ""/
 {
-    $path = @open_path[tid];
+    $path = @open_info[tid].path;
     if (strcontains($path, ".ssh/") ||
         strcontains($path, ".gnupg/") ||
         strcontains($path, ".docker/") ||
@@ -83,7 +81,7 @@ tracepoint:syscalls:sys_exit_openat
         strcontains($path, ".aws/") ||
         strcontains($path, ".azure/")) {
         $t = nsecs;
-        $mode = @open_write[tid] ? "W" : "R";
+        $mode = @open_info[tid].write ? "W" : "R";
         printf("%s.%03d      !SECRET[%s] %s\n",
             ts_str($t), ts_ms($t), $mode, $path);
     }
@@ -92,16 +90,16 @@ tracepoint:syscalls:sys_exit_openat
 // --- Credential / secret files (2/2) ---
 // .env files, token/secret/credential files, .netrc, /etc/shadow.
 tracepoint:syscalls:sys_exit_openat
-/@open_path[tid] != ""/
+/@open_info[tid].path != ""/
 {
-    $path = @open_path[tid];
+    $path = @open_info[tid].path;
     if (strcontains($path, ".env") ||
         strcontains($path, "token") ||
         strcontains($path, "secret") ||
         strcontains($path, ".netrc") ||
         strcontains($path, "/etc/shadow")) {
         $t = nsecs;
-        $mode = @open_write[tid] ? "W" : "R";
+        $mode = @open_info[tid].write ? "W" : "R";
         printf("%s.%03d      !SECRET[%s] %s\n",
             ts_str($t), ts_ms($t), $mode, $path);
     }
@@ -111,9 +109,9 @@ tracepoint:syscalls:sys_exit_openat
 // Writing to cron or systemd directories installs commands that persist
 // and run after the process exits.
 tracepoint:syscalls:sys_exit_openat
-/@open_write[tid]/
+/@open_info[tid].write/
 {
-    $path = @open_path[tid];
+    $path = @open_info[tid].path;
     if (strcontains($path, "/etc/cron") ||
         strcontains($path, "/spool/cron/") ||
         strcontains($path, "/etc/systemd/") ||
@@ -129,9 +127,9 @@ tracepoint:syscalls:sys_exit_openat
 // Modifying .bashrc, .zshrc, .profile etc. lets a process inject commands
 // that run every time the user opens a shell.
 tracepoint:syscalls:sys_exit_openat
-/@open_write[tid]/
+/@open_info[tid].write/
 {
-    $path = @open_path[tid];
+    $path = @open_info[tid].path;
     if (strcontains($path, ".profile") ||
         strcontains($path, ".bashrc") ||
         strcontains($path, ".bash_profile") ||
@@ -142,8 +140,7 @@ tracepoint:syscalls:sys_exit_openat
             ts_str($t), ts_ms($t), "!SHRC_W", $path);
     }
 
-    delete(@open_path[tid]);
-    delete(@open_write[tid]);
+    delete(@open_info[tid]);
 }
 
 // ========================================================================
@@ -159,7 +156,7 @@ tracepoint:syscalls:sys_enter_setuid
 {
     $t = nsecs;
     printf("%s.%03d      %-10s uid=%d\n",
-        ts_str($t), ts_ms($t), "!SETUID", args->uid);
+        ts_str($t), ts_ms($t), "!SETUID", args.uid);
 }
 
 tracepoint:syscalls:sys_enter_setgid
@@ -167,7 +164,7 @@ tracepoint:syscalls:sys_enter_setgid
 {
     $t = nsecs;
     printf("%s.%03d      %-10s gid=%d\n",
-        ts_str($t), ts_ms($t), "!SETGID", args->gid);
+        ts_str($t), ts_ms($t), "!SETGID", args.gid);
 }
 
 // setresuid / setresgid — set real, effective, and saved user/group IDs.
@@ -178,7 +175,7 @@ tracepoint:syscalls:sys_enter_setresuid
     $t = nsecs;
     printf("%s.%03d      %-10s ruid=%d euid=%d suid=%d\n",
         ts_str($t), ts_ms($t), "!SETRESUID",
-        args->ruid, args->euid, args->suid);
+        args.ruid, args.euid, args.suid);
 }
 
 tracepoint:syscalls:sys_enter_setresgid
@@ -187,7 +184,7 @@ tracepoint:syscalls:sys_enter_setresgid
     $t = nsecs;
     printf("%s.%03d      %-10s rgid=%d egid=%d sgid=%d\n",
         ts_str($t), ts_ms($t), "!SETRESGID",
-        args->rgid, args->egid, args->sgid);
+        args.rgid, args.egid, args.sgid);
 }
 
 // capset — modify process capabilities (e.g. granting CAP_NET_RAW,
@@ -212,7 +209,7 @@ tracepoint:syscalls:sys_enter_ptrace
 {
     $t = nsecs;
     printf("%s.%03d      %-10s request=%ld target_pid=%ld\n",
-        ts_str($t), ts_ms($t), "!PTRACE", args->request, args->pid);
+        ts_str($t), ts_ms($t), "!PTRACE", args.request, args.pid);
 }
 
 // mount / umount — mounting filesystems can be used to overlay system
@@ -223,7 +220,7 @@ tracepoint:syscalls:sys_enter_mount
     $t = nsecs;
     printf("%s.%03d      %-10s %s on %s type %s\n",
         ts_str($t), ts_ms($t), "!MOUNT",
-        str(args->dev_name), str(args->dir_name), str(args->type));
+        str(args.dev_name), str(args.dir_name), str(args.type));
 }
 
 tracepoint:syscalls:sys_enter_umount
@@ -231,7 +228,7 @@ tracepoint:syscalls:sys_enter_umount
 {
     $t = nsecs;
     printf("%s.%03d      %-10s %s\n",
-        ts_str($t), ts_ms($t), "!UMOUNT", str(args->name));
+        ts_str($t), ts_ms($t), "!UMOUNT", str(args.name));
 }
 
 // init_module / finit_module — loading kernel modules gives full kernel
@@ -241,7 +238,7 @@ tracepoint:syscalls:sys_enter_init_module
 {
     $t = nsecs;
     printf("%s.%03d      %-10s size=%lu\n",
-        ts_str($t), ts_ms($t), "!KMOD", args->len);
+        ts_str($t), ts_ms($t), "!KMOD", args.len);
 }
 
 tracepoint:syscalls:sys_enter_finit_module
@@ -249,7 +246,7 @@ tracepoint:syscalls:sys_enter_finit_module
 {
     $t = nsecs;
     printf("%s.%03d      %-10s fd=%d\n",
-        ts_str($t), ts_ms($t), "!KMOD", args->fd);
+        ts_str($t), ts_ms($t), "!KMOD", args.fd);
 }
 
 // sethostname / setdomainname — changing the system's identity is not
@@ -259,7 +256,7 @@ tracepoint:syscalls:sys_enter_sethostname
 {
     $t = nsecs;
     printf("%s.%03d      %-10s %s\n",
-        ts_str($t), ts_ms($t), "!SETHOST", str(args->name));
+        ts_str($t), ts_ms($t), "!SETHOST", str(args.name));
 }
 
 tracepoint:syscalls:sys_enter_setdomainname
@@ -267,7 +264,7 @@ tracepoint:syscalls:sys_enter_setdomainname
 {
     $t = nsecs;
     printf("%s.%03d      %-10s %s\n",
-        ts_str($t), ts_ms($t), "!SETDOM", str(args->name));
+        ts_str($t), ts_ms($t), "!SETDOM", str(args.name));
 }
 
 // ========================================================================
@@ -283,18 +280,18 @@ tracepoint:syscalls:sys_enter_memfd_create
     $t = nsecs;
     printf("%s.%03d      %-10s name=%s flags=0x%x\n",
         ts_str($t), ts_ms($t), "!MEMFD",
-        str(args->uname), args->flags);
+        str(args.uname), args.flags);
 }
 
 // socket with SOCK_RAW (type 3) — raw sockets allow crafting arbitrary
 // network packets, used for network scanning, spoofing, or covert channels.
 tracepoint:syscalls:sys_enter_socket
-/@watched[(int64)pid] && args->type == 3/
+/@watched[(int64)pid] && args.type == 3/
 {
     $t = nsecs;
     printf("%s.%03d      %-10s family=%d protocol=%d\n",
         ts_str($t), ts_ms($t), "!RAW_SOCK",
-        args->family, args->protocol);
+        args.family, args.protocol);
 }
 
 // ========================================================================
@@ -307,10 +304,10 @@ tracepoint:syscalls:sys_enter_socket
 // Parse the sockaddr to show what address/port is being bound.
 // Skip AF_NETLINK (16) — normal kernel-userspace IPC, not a network concern.
 tracepoint:syscalls:sys_enter_bind
-/@watched[(int64)pid] && *(uint16 *)args->umyaddr != 16/
+/@watched[(int64)pid] && *(uint16 *)args.umyaddr != 16/
 {
     $t = nsecs;
-    $sa = (uint8 *)args->umyaddr;
+    $sa = (uint8 *)args.umyaddr;
     $family = *(uint16 *)$sa;
     // Port is at offset 2 in both sockaddr_in and sockaddr_in6 (big-endian)
     $port_be = *(uint16 *)($sa + 2);
@@ -319,17 +316,17 @@ tracepoint:syscalls:sys_enter_bind
     if ($family == 2) {  // AF_INET
         $addr = ntop(*(uint32 *)($sa + 4));
         printf("%s.%03d      %-10s fd=%d AF_INET %s:%d\n",
-            ts_str($t), ts_ms($t), "!BIND", args->fd, $addr, $port);
+            ts_str($t), ts_ms($t), "!BIND", args.fd, $addr, $port);
     } else if ($family == 10) {  // AF_INET6
         printf("%s.%03d      %-10s fd=%d AF_INET6 port=%d\n",
-            ts_str($t), ts_ms($t), "!BIND", args->fd, $port);
+            ts_str($t), ts_ms($t), "!BIND", args.fd, $port);
     } else if ($family == 1) {  // AF_UNIX
         $path = str($sa + 2);
         printf("%s.%03d      %-10s fd=%d AF_UNIX %s\n",
-            ts_str($t), ts_ms($t), "!BIND", args->fd, $path);
+            ts_str($t), ts_ms($t), "!BIND", args.fd, $path);
     } else {
         printf("%s.%03d      %-10s fd=%d family=%d\n",
-            ts_str($t), ts_ms($t), "!BIND", args->fd, $family);
+            ts_str($t), ts_ms($t), "!BIND", args.fd, $family);
     }
 }
 
@@ -339,7 +336,7 @@ tracepoint:syscalls:sys_enter_listen
 {
     $t = nsecs;
     printf("%s.%03d      %-10s fd=%d backlog=%d\n",
-        ts_str($t), ts_ms($t), "!LISTEN", args->fd, args->backlog);
+        ts_str($t), ts_ms($t), "!LISTEN", args.fd, args.backlog);
 }
 
 // accept / accept4 — accepting an incoming connection.
@@ -348,7 +345,7 @@ tracepoint:syscalls:sys_enter_accept
 {
     $t = nsecs;
     printf("%s.%03d      %-10s fd=%d\n",
-        ts_str($t), ts_ms($t), "!ACCEPT", args->fd);
+        ts_str($t), ts_ms($t), "!ACCEPT", args.fd);
 }
 
 tracepoint:syscalls:sys_enter_accept4
@@ -356,7 +353,7 @@ tracepoint:syscalls:sys_enter_accept4
 {
     $t = nsecs;
     printf("%s.%03d      %-10s fd=%d\n",
-        ts_str($t), ts_ms($t), "!ACCEPT", args->fd);
+        ts_str($t), ts_ms($t), "!ACCEPT", args.fd);
 }
 
 // ========================================================================
@@ -370,7 +367,7 @@ tracepoint:syscalls:sys_enter_process_vm_readv
 {
     $t = nsecs;
     printf("%s.%03d      %-10s target_pid=%ld\n",
-        ts_str($t), ts_ms($t), "!VM_READ", args->pid);
+        ts_str($t), ts_ms($t), "!VM_READ", args.pid);
 }
 
 tracepoint:syscalls:sys_enter_process_vm_writev
@@ -378,7 +375,7 @@ tracepoint:syscalls:sys_enter_process_vm_writev
 {
     $t = nsecs;
     printf("%s.%03d      %-10s target_pid=%ld\n",
-        ts_str($t), ts_ms($t), "!VM_WRITE", args->pid);
+        ts_str($t), ts_ms($t), "!VM_WRITE", args.pid);
 }
 
 // ========================================================================
@@ -393,7 +390,7 @@ tracepoint:syscalls:sys_enter_unshare
 {
     $t = nsecs;
     printf("%s.%03d      %-10s flags=0x%lx\n",
-        ts_str($t), ts_ms($t), "!UNSHARE", args->unshare_flags);
+        ts_str($t), ts_ms($t), "!UNSHARE", args.unshare_flags);
 }
 
 tracepoint:syscalls:sys_enter_chroot
@@ -401,7 +398,7 @@ tracepoint:syscalls:sys_enter_chroot
 {
     $t = nsecs;
     printf("%s.%03d      %-10s %s\n",
-        ts_str($t), ts_ms($t), "!CHROOT", str(args->filename));
+        ts_str($t), ts_ms($t), "!CHROOT", str(args.filename));
 }
 
 tracepoint:syscalls:sys_enter_pivot_root
@@ -410,7 +407,7 @@ tracepoint:syscalls:sys_enter_pivot_root
     $t = nsecs;
     printf("%s.%03d      %-10s %s -> %s\n",
         ts_str($t), ts_ms($t), "!PIVROOT",
-        str(args->new_root), str(args->put_old));
+        str(args.new_root), str(args.put_old));
 }
 
 // ========================================================================
@@ -421,19 +418,19 @@ tracepoint:syscalls:sys_enter_pivot_root
 // Classic shellcode injection: allocate RW memory, write payload, flip
 // to executable with mprotect.
 tracepoint:syscalls:sys_enter_mprotect
-/@watched[(int64)pid] && (args->prot & 0x4)/
+/@watched[(int64)pid] && (args.prot & 0x4)/
 {
     $t = nsecs;
     printf("%s.%03d      %-10s addr=0x%lx len=%lu prot=0x%lx\n",
         ts_str($t), ts_ms($t), "!MPROT_X",
-        args->start, args->len, args->prot);
+        args.start, args.len, args.prot);
 }
 
 // prctl PR_SET_DUMPABLE=0 (arg0=4, arg1=0) — makes the process
 // non-dumpable, preventing core dumps and /proc/pid/mem reads.
 // Anti-forensics technique to hide process memory from inspection.
 tracepoint:syscalls:sys_enter_prctl
-/@watched[(int64)pid] && args->option == 4 && args->arg2 == 0/
+/@watched[(int64)pid] && args.option == 4 && args.arg2 == 0/
 {
     $t = nsecs;
     printf("%s.%03d      %-10s PR_SET_DUMPABLE=0\n",
@@ -447,7 +444,7 @@ tracepoint:syscalls:sys_enter_seccomp
 {
     $t = nsecs;
     printf("%s.%03d      %-10s op=%u flags=%u\n",
-        ts_str($t), ts_ms($t), "!SECCOMP", args->op, args->flags);
+        ts_str($t), ts_ms($t), "!SECCOMP", args.op, args.flags);
 }
 
 // personality — changing process execution domain. Can be used to
@@ -457,7 +454,7 @@ tracepoint:syscalls:sys_enter_personality
 {
     $t = nsecs;
     printf("%s.%03d      %-10s persona=0x%lx\n",
-        ts_str($t), ts_ms($t), "!PERSONA", args->personality);
+        ts_str($t), ts_ms($t), "!PERSONA", args.personality);
 }
 
 // userfaultfd — used in kernel race-condition exploits. No legitimate
@@ -467,7 +464,7 @@ tracepoint:syscalls:sys_enter_userfaultfd
 {
     $t = nsecs;
     printf("%s.%03d      %-10s flags=0x%x\n",
-        ts_str($t), ts_ms($t), "!UFFD", args->flags);
+        ts_str($t), ts_ms($t), "!UFFD", args.flags);
 }
 
 // ========================================================================
@@ -482,7 +479,7 @@ tracepoint:syscalls:sys_enter_symlinkat
     $t = nsecs;
     printf("%s.%03d      %-10s %s -> %s\n",
         ts_str($t), ts_ms($t), "!SYMLINK",
-        str(args->oldname), str(args->newname));
+        str(args.oldname), str(args.newname));
 }
 
 tracepoint:syscalls:sys_enter_linkat
@@ -491,7 +488,7 @@ tracepoint:syscalls:sys_enter_linkat
     $t = nsecs;
     printf("%s.%03d      %-10s %s -> %s\n",
         ts_str($t), ts_ms($t), "!HARDLINK",
-        str(args->oldname), str(args->newname));
+        str(args.oldname), str(args.newname));
 }
 
 // ========================================================================
@@ -505,7 +502,7 @@ tracepoint:syscalls:sys_enter_keyctl
 {
     $t = nsecs;
     printf("%s.%03d      %-10s operation=%d\n",
-        ts_str($t), ts_ms($t), "!KEYCTL", args->option);
+        ts_str($t), ts_ms($t), "!KEYCTL", args.option);
 }
 
 // ========================================================================
@@ -518,17 +515,17 @@ tracepoint:syscalls:sys_enter_reboot
 {
     $t = nsecs;
     printf("%s.%03d      %-10s magic=0x%x cmd=0x%x\n",
-        ts_str($t), ts_ms($t), "!REBOOT", args->magic1, args->cmd);
+        ts_str($t), ts_ms($t), "!REBOOT", args.magic1, args.cmd);
 }
 
 // kill — sending signals to processes outside the watched tree could be
 // used to interfere with monitoring or other system processes.
 tracepoint:syscalls:sys_enter_kill
-/@watched[(int64)pid] && !@watched[(int64)args->pid] && args->pid > 0/
+/@watched[(int64)pid] && !@watched[(int64)args.pid] && args.pid > 0/
 {
     $t = nsecs;
     printf("%s.%03d      %-10s target_pid=%d signal=%d\n",
-        ts_str($t), ts_ms($t), "!KILL_EXT", args->pid, args->sig);
+        ts_str($t), ts_ms($t), "!KILL_EXT", args.pid, args.sig);
 }
 
 // ========================================================================
@@ -539,12 +536,12 @@ tracepoint:syscalls:sys_enter_kill
 // binaries is a classic privilege escalation technique. A process could
 // compile a helper binary and make it setuid-root.
 tracepoint:syscalls:sys_enter_fchmodat
-/@watched[(int64)pid] && (args->mode & 06000)/
+/@watched[(int64)pid] && (args.mode & 06000)/
 {
     $t = nsecs;
     printf("%s.%03d      %-10s %s (mode %o — setuid/setgid!)\n",
         ts_str($t), ts_ms($t), "!SUID_CHM",
-        str(args->filename), args->mode);
+        str(args.filename), args.mode);
 }
 
 // --- Process tracking ---
@@ -565,7 +562,6 @@ tracepoint:sched:sched_process_exit
 END
 {
     clear(@watched);
-    clear(@open_path);
-    clear(@open_write);
+    clear(@open_info);
     delete(@root_pid);
 }

--- a/coding/process-supervisor/trace-suspicious.bt
+++ b/coding/process-supervisor/trace-suspicious.bt
@@ -1,10 +1,9 @@
-#!/usr/bin/env bpftrace
 /*
- * trace-suspicious.bt
+ * trace-suspicious.bt — Suspicious operation tracer module
  *
- * Monitor suspicious or potentially abusive operations performed by a
- * process and its descendants. Designed to catch processes performing
- * suspicious or potentially dangerous operations.
+ * Monitor suspicious or potentially abusive operations performed by the
+ * watched process tree. Designed to catch processes performing suspicious
+ * or potentially dangerous operations.
  *
  * Categories of suspicious activity:
  *   - Credential/secret access (reading SSH keys, tokens, .env files)
@@ -22,34 +21,9 @@
  *   - Destructive actions (reboot, kill outside watched tree)
  *   - Permission manipulation (setting setuid/setgid bits)
  *
- * Requires: kernel BTF support (CONFIG_DEBUG_INFO_BTF=y), bpftrace >= 0.25
- * Usage: sudo bpftrace trace-suspicious.bt <PID>
+ * Requires trace-common.bt preamble:
+ *   cat trace-common.bt trace-suspicious.bt | sudo bpftrace - <PID>
  */
-
-// Timestamp: HH:MM:SS string and milliseconds within the current second
-macro ts_str(t) { strftime("%H:%M:%S", t) }
-macro ts_ms(t)  { (t % 1000000000) / 1000000 }
-
-BEGIN
-{
-    if ($1 == 0) {
-        printf("Usage: sudo bpftrace trace-suspicious.bt <PID>\n");
-        exit();
-    }
-    printf("Monitoring suspicious operations of PID %d (and their children)...\n", $1);
-    printf("%-20s %-10s %s\n", "TIME", "EVENT", "DETAILS");
-    printf("%-20s %-10s %s\n", "----", "-----", "-------");
-
-    @root_pid = $1;
-    @watched[($1)] = 1;
-}
-
-tracepoint:sched:sched_process_fork
-{
-    if (@watched[(int64)pid]) {
-        @watched[args.child_pid] = 1;
-    }
-}
 
 // ========================================================================
 // Credential / secret access
@@ -63,7 +37,7 @@ tracepoint:sched:sched_process_fork
 tracepoint:syscalls:sys_enter_openat
 /@watched[(int64)pid]/
 {
-    @open_info[tid] = (path=str(args.filename, 64),
+    @sus_open[tid] = (path=str(args.filename, 64),
                        write=(args.flags & 3) > 0 || (args.flags & 0x40) ? 1 : 0);
 }
 
@@ -71,9 +45,9 @@ tracepoint:syscalls:sys_enter_openat
 // SSH keys, GPG keyrings, cloud credentials, GitHub CLI tokens.
 // The traced process has no business reading these.
 tracepoint:syscalls:sys_exit_openat
-/@open_info[tid].path != ""/
+/@sus_open[tid].path != ""/
 {
-    $path = @open_info[tid].path;
+    $path = @sus_open[tid].path;
     if (strcontains($path, ".ssh/") ||
         strcontains($path, ".gnupg/") ||
         strcontains($path, ".docker/") ||
@@ -81,7 +55,7 @@ tracepoint:syscalls:sys_exit_openat
         strcontains($path, ".aws/") ||
         strcontains($path, ".azure/")) {
         $t = nsecs;
-        $mode = @open_info[tid].write ? "W" : "R";
+        $mode = @sus_open[tid].write ? "W" : "R";
         printf("%s.%03d      !SECRET[%s] %s\n",
             ts_str($t), ts_ms($t), $mode, $path);
     }
@@ -90,16 +64,16 @@ tracepoint:syscalls:sys_exit_openat
 // --- Credential / secret files (2/2) ---
 // .env files, token/secret/credential files, .netrc, /etc/shadow.
 tracepoint:syscalls:sys_exit_openat
-/@open_info[tid].path != ""/
+/@sus_open[tid].path != ""/
 {
-    $path = @open_info[tid].path;
+    $path = @sus_open[tid].path;
     if (strcontains($path, ".env") ||
         strcontains($path, "token") ||
         strcontains($path, "secret") ||
         strcontains($path, ".netrc") ||
         strcontains($path, "/etc/shadow")) {
         $t = nsecs;
-        $mode = @open_info[tid].write ? "W" : "R";
+        $mode = @sus_open[tid].write ? "W" : "R";
         printf("%s.%03d      !SECRET[%s] %s\n",
             ts_str($t), ts_ms($t), $mode, $path);
     }
@@ -109,9 +83,9 @@ tracepoint:syscalls:sys_exit_openat
 // Writing to cron or systemd directories installs commands that persist
 // and run after the process exits.
 tracepoint:syscalls:sys_exit_openat
-/@open_info[tid].write/
+/@sus_open[tid].write/
 {
-    $path = @open_info[tid].path;
+    $path = @sus_open[tid].path;
     if (strcontains($path, "/etc/cron") ||
         strcontains($path, "/spool/cron/") ||
         strcontains($path, "/etc/systemd/") ||
@@ -127,9 +101,9 @@ tracepoint:syscalls:sys_exit_openat
 // Modifying .bashrc, .zshrc, .profile etc. lets a process inject commands
 // that run every time the user opens a shell.
 tracepoint:syscalls:sys_exit_openat
-/@open_info[tid].write/
+/@sus_open[tid].write/
 {
-    $path = @open_info[tid].path;
+    $path = @sus_open[tid].path;
     if (strcontains($path, ".profile") ||
         strcontains($path, ".bashrc") ||
         strcontains($path, ".bash_profile") ||
@@ -140,7 +114,7 @@ tracepoint:syscalls:sys_exit_openat
             ts_str($t), ts_ms($t), "!SHRC_W", $path);
     }
 
-    delete(@open_info[tid]);
+    $_ = delete(@sus_open[tid]);
 }
 
 // ========================================================================
@@ -310,8 +284,7 @@ tracepoint:syscalls:sys_enter_bind
     $sa = (uint8 *)args.umyaddr;
     $family = *(uint16 *)$sa;
     // Port is at offset 2 in both sockaddr_in and sockaddr_in6 (big-endian)
-    $port_be = *(uint16 *)($sa + 2);
-    $port = ($port_be >> 8) | (($port_be & 0xff) << 8);
+    $port = ntohs(*(uint16 *)($sa + 2));
 
     if ($family == 2) {  // AF_INET
         $addr = ntop(*(uint32 *)($sa + 4));
@@ -544,24 +517,7 @@ tracepoint:syscalls:sys_enter_fchmodat
         str(args.filename), args.mode);
 }
 
-// --- Process tracking ---
-
-tracepoint:sched:sched_process_exit
-/(@watched[(int64)pid]) && tid == pid/
-{
-    delete(@watched[(int64)pid]);
-}
-
-tracepoint:sched:sched_process_exit
-/(tid == (uint64)@root_pid)/
-{
-    printf("\nRoot process %d exited. Stopping monitor.\n", @root_pid);
-    exit();
-}
-
 END
 {
-    clear(@watched);
-    clear(@open_info);
-    delete(@root_pid);
+    clear(@sus_open);
 }


### PR DESCRIPTION
    
    Leverage bpftrace 0.25.0 features to improve and factorize the
    monitoring scripts:
    
    - Remove unstable_macro config (macros now stable)
    - Use auto-dereferencing `.` operator instead of `->` (now preferred)
    - Use record primitive to merge paired maps (@open_path + @open_write
      into @open_info) in trace-suspicious.bt and trace-files.bt
    - Add comm[pid] context to EXEC events in trace-execs.bt
    - Replace stdbuf -oL wrapping with native bpftrace -B line flag
      (v0.25 extended -B buffering to file outputs)
    - Extract shared boilerplate into trace-common.bt (macros, BEGIN,
      fork tracking) and refactor tracers into composable modules
    - Concatenate modules into a single bpftrace process instead of
      running 4 separate processes (enabled by multiple BEGIN/END support)
    - stable macros (drop unstable_macro config)
    - auto-dereferencing dot operator (-> to .)
    - native line-buffered output (-B line instead of stdbuf -oL)
    - record syntax for open-info maps
    - add comm context to EXEC events