### PR TITLE
[coding] Extract process-monitoring lifecycle teardown into a dedicated cleanup module

### DIFF
--- a/coding/process-supervisor/cleanup.bt
+++ b/coding/process-supervisor/cleanup.bt
@@ -1,0 +1,37 @@
+/*
+ * cleanup.bt
+ *
+ * Shared cleanup for process monitoring scripts. Handles process-tree
+ * shrinking and stops the tracer when the root process exits.
+ *
+ * Must be concatenated AFTER all tracer modules (common.bt first,
+ * then modules, then this file) so that module-specific END handlers
+ * (e.g. the netcalls aggregation flush) fire before @watched is cleared:
+ *
+ *   cat common.bt trace-files.bt cleanup.bt | sudo bpftrace - <PID>
+ *
+ * Not intended to be run standalone.
+ *
+ * Requires: common.bt preamble (defines @watched, @root_pid)
+ */
+
+// Remove a watched process from tracking when it exits
+tracepoint:sched:sched_process_exit
+/(@watched[(int64)pid]) && tid == pid/
+{
+    $_ = delete(@watched[(int64)pid]);
+}
+
+// Stop tracing when the root process exits
+tracepoint:sched:sched_process_exit
+/(tid == (uint64)@root_pid)/
+{
+    printf("\nRoot process %d exited. Stopping monitor.\n", @root_pid);
+    exit();
+}
+
+END
+{
+    clear(@watched);
+    $_ = delete(@root_pid);
+}

--- a/coding/process-supervisor/common.bt
+++ b/coding/process-supervisor/common.bt
@@ -1,5 +1,5 @@
 /*
- * trace-common.bt
+ * common.bt
  *
  * Shared preamble for process monitoring scripts. Provides timestamp
  * macros, process-tree tracking, and lifecycle management.
@@ -7,7 +7,7 @@
  * Not intended to be run standalone. Combined with tracer modules by
  * monitor-process.sh (or manually via cat):
  *
- *   cat trace-common.bt trace-files.bt | sudo bpftrace - <PID>
+ *   cat common.bt trace-files.bt cleanup.bt | sudo bpftrace - <PID>
  *
  * Requires: kernel BTF support (CONFIG_DEBUG_INFO_BTF=y), bpftrace >= 0.25
  */

--- a/coding/process-supervisor/monitor-process.sh
+++ b/coding/process-supervisor/monitor-process.sh
@@ -2,7 +2,7 @@
 #
 # monitor-process.sh
 #
-# Builds a combined bpftrace script from trace-common.bt and the enabled
+# Builds a combined bpftrace script from common.bt and the enabled
 # tracer modules (execs, files, netcalls, suspicious), then runs a single
 # bpftrace process with elevated privileges to monitor a process and all
 # its descendants.
@@ -154,14 +154,14 @@ if [[ -z "$ATTACH_PID" && $# -eq 0 ]]; then
 fi
 
 # --- Build combined bpftrace script ---
-# Concatenate trace-common.bt (shared preamble) with enabled tracer
-# modules, then append a shared postamble for process-exit cleanup.
-# Tracer-specific exit handlers (e.g. netcalls flush_agg) are placed
-# before the shared handler so they fire first.
+# Concatenate common.bt (shared preamble) with enabled tracer
+# modules, then append cleanup.bt for process-exit teardown.
+# Tracer-specific END handlers (e.g. netcalls flush_agg) are placed
+# before cleanup so they fire first.
 TRACERS_ENABLED=0
 COMBINED_SCRIPT=$(mktemp "/tmp/monitor-combined.XXXXXX.bt")
 
-cat "$SCRIPT_DIR/trace-common.bt" >> "$COMBINED_SCRIPT"
+cat "$SCRIPT_DIR/common.bt" >> "$COMBINED_SCRIPT"
 
 if [[ "$TRACE_EXECS" -eq 1 ]]; then
     echo "[monitor-process] Including exec tracer"
@@ -193,32 +193,10 @@ if [[ "$TRACERS_ENABLED" -eq 0 ]]; then
     exit 1
 fi
 
-# Append shared postamble: process-exit cleanup and root-exit handler.
-# This must come AFTER all tracer modules so that tracer-specific exit
-# handlers (e.g. netcalls flush_agg) fire before @watched is cleaned up.
-cat >> "$COMBINED_SCRIPT" << 'POSTAMBLE'
-
-// --- Shared process tracking (appended by monitor-process.sh) ---
-
-tracepoint:sched:sched_process_exit
-/(@watched[(int64)pid]) && tid == pid/
-{
-    $_ = delete(@watched[(int64)pid]);
-}
-
-tracepoint:sched:sched_process_exit
-/(tid == (uint64)@root_pid)/
-{
-    printf("\nRoot process %d exited. Stopping monitor.\n", @root_pid);
-    exit();
-}
-
-END
-{
-    clear(@watched);
-    $_ = delete(@root_pid);
-}
-POSTAMBLE
+# Append shared cleanup: process-exit shrinking and root-exit handler.
+# Must come AFTER all tracer modules so that tracer-specific END handlers
+# (e.g. netcalls flush_agg) fire before @watched is cleared.
+cat "$SCRIPT_DIR/cleanup.bt" >> "$COMBINED_SCRIPT"
 
 # --- Output setup ---
 # In attach mode, default to stdout (no interleaving risk since we

--- a/coding/process-supervisor/trace-all.sh
+++ b/coding/process-supervisor/trace-all.sh
@@ -2,7 +2,7 @@
 #
 # trace-all.sh
 #
-# Concatenates trace-common.bt with all trace-*.bt modules and runs
+# Concatenates common.bt with all trace-*.bt modules and runs
 # them as a single bpftrace process against the target PID.
 #
 # Usage: sudo ./trace-all.sh <PID>
@@ -18,39 +18,18 @@ fi
 
 PID="$1"
 
-# Build combined script: common preamble + all tracer modules + postamble
+# Build combined script: common preamble + all tracer modules + cleanup
 COMBINED=$(mktemp "/tmp/trace-all.XXXXXX.bt")
 trap 'rm -f "$COMBINED"' EXIT INT TERM QUIT HUP
 
-cat "$SCRIPT_DIR/trace-common.bt" > "$COMBINED"
+cat "$SCRIPT_DIR/common.bt" > "$COMBINED"
 
 for module in "$SCRIPT_DIR"/trace-{execs,files,netcalls,suspicious}.bt; do
     cat "$module" >> "$COMBINED"
 done
 
-# Shared postamble: process-exit cleanup and root-exit handler
-cat >> "$COMBINED" << 'POSTAMBLE'
-
-// --- Shared process tracking (appended by trace-all.sh) ---
-
-tracepoint:sched:sched_process_exit
-/(@watched[(int64)pid]) && tid == pid/
-{
-    delete(@watched[(int64)pid]);
-}
-
-tracepoint:sched:sched_process_exit
-/(tid == (uint64)@root_pid)/
-{
-    printf("\nRoot process %d exited. Stopping monitor.\n", @root_pid);
-    exit();
-}
-
-END
-{
-    clear(@watched);
-    delete(@root_pid);
-}
-POSTAMBLE
+# Shared cleanup: process-exit shrinking and root-exit handler
+# Must come last so module-specific END handlers fire before @watched is cleared.
+cat "$SCRIPT_DIR/cleanup.bt" >> "$COMBINED"
 
 bpftrace -B line "$COMBINED" "$PID"

--- a/coding/process-supervisor/trace-execs.bt
+++ b/coding/process-supervisor/trace-execs.bt
@@ -5,8 +5,8 @@
  * For each exec() call, print the timestamp, caller comm/PID, and full
  * command with args.
  *
- * Requires trace-common.bt preamble:
- *   cat trace-common.bt trace-execs.bt | sudo bpftrace - <PID>
+ * Requires common.bt preamble and cleanup.bt:
+ *   cat common.bt trace-execs.bt cleanup.bt | sudo bpftrace - <PID>
  */
 
 // On exec, if the process is watched, log the command

--- a/coding/process-supervisor/trace-files.bt
+++ b/coding/process-supervisor/trace-files.bt
@@ -4,8 +4,8 @@
  * Monitor file operations (open, read, write, mkdir, delete, rename,
  * chmod, chown) made by the watched process tree.
  *
- * Requires trace-common.bt preamble:
- *   cat trace-common.bt trace-files.bt | sudo bpftrace - <PID>
+ * Requires common.bt preamble and cleanup.bt:
+ *   cat common.bt trace-files.bt cleanup.bt | sudo bpftrace - <PID>
  */
 
 // --- File open ---

--- a/coding/process-supervisor/trace-netcalls.bt
+++ b/coding/process-supervisor/trace-netcalls.bt
@@ -11,8 +11,8 @@
  * user-space pointer reads that silently fail on kernel 5.5+
  * (bpf_probe_read vs bpf_probe_read_user).
  *
- * Requires trace-common.bt preamble:
- *   cat trace-common.bt trace-netcalls.bt | sudo bpftrace - <PID>
+ * Requires common.bt preamble and cleanup.bt:
+ *   cat common.bt trace-netcalls.bt cleanup.bt | sudo bpftrace - <PID>
  */
 
 // --- Macros ---

--- a/coding/process-supervisor/trace-suspicious.bt
+++ b/coding/process-supervisor/trace-suspicious.bt
@@ -21,8 +21,8 @@
  *   - Destructive actions (reboot, kill outside watched tree)
  *   - Permission manipulation (setting setuid/setgid bits)
  *
- * Requires trace-common.bt preamble:
- *   cat trace-common.bt trace-suspicious.bt | sudo bpftrace - <PID>
+ * Requires common.bt preamble and cleanup.bt:
+ *   cat common.bt trace-suspicious.bt cleanup.bt | sudo bpftrace - <PID>
  */
 
 // ========================================================================


### PR DESCRIPTION

Move process-exit shrinking and root-exit teardown into cleanup.bt, separate from the shared preamble, so module-specific END handlers (e.g. netcalls flush_agg) fire before @watched is cleared.